### PR TITLE
V4.1.0: Dry Runs & Coupons discount limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>one.talon</groupId>
   <artifactId>talon-one-client</artifactId>
-  <version>4.0.0</version>
+  <version>4.1.0</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -59,7 +59,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "one.talon:talon-one-client:4.0.0"
+compile "one.talon:talon-one-client:4.1.0"
 ```
 
 ### Others
@@ -72,7 +72,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/talon-one-client-4.0.0.jar`
+* `target/talon-one-client-4.1.0.jar`
 * `target/lib/*.jar`
 
 ## Getting Started
@@ -239,10 +239,10 @@ Class | Method | HTTP request | Description
 *IntegrationApi* | [**deleteCouponReservation**](docs/IntegrationApi.md#deleteCouponReservation) | **DELETE** /v1/coupon_reservations/{couponValue} | Delete coupon reservations
 *IntegrationApi* | [**deleteCustomerData**](docs/IntegrationApi.md#deleteCustomerData) | **DELETE** /v1/customer_data/{integrationId} | Delete the personal data of a customer.
 *IntegrationApi* | [**getCustomerInventory**](docs/IntegrationApi.md#getCustomerInventory) | **GET** /v1/customer_profiles/{integrationId}/inventory | Get an inventory of all data associated with a specific customer profile.
-*IntegrationApi* | [**getReservedCoupons**](docs/IntegrationApi.md#getReservedCoupons) | **GET** /v1/coupon_reservations/coupons/{integrationId} | Get all valid reserved coupons
 *IntegrationApi* | [**getReservedCustomers**](docs/IntegrationApi.md#getReservedCustomers) | **GET** /v1/coupon_reservations/customerprofiles/{couponValue} | Get the users that have this coupon reserved
 *IntegrationApi* | [**trackEvent**](docs/IntegrationApi.md#trackEvent) | **POST** /v1/events | Track an Event
 *IntegrationApi* | [**updateCustomerProfile**](docs/IntegrationApi.md#updateCustomerProfile) | **PUT** /v1/customer_profiles/{integrationId} | Update a Customer Profile
+*IntegrationApi* | [**updateCustomerProfileV2**](docs/IntegrationApi.md#updateCustomerProfileV2) | **PUT** /v2/customer_profiles/{customerProfileId} | Update a Customer Profile
 *IntegrationApi* | [**updateCustomerSession**](docs/IntegrationApi.md#updateCustomerSession) | **PUT** /v1/customer_sessions/{customerSessionId} | Update a Customer Session
 *IntegrationApi* | [**updateCustomerSessionV2**](docs/IntegrationApi.md#updateCustomerSessionV2) | **PUT** /v2/customer_sessions/{customerSessionId} | Update a Customer Session
 *ManagementApi* | [**addLoyaltyPoints**](docs/ManagementApi.md#addLoyaltyPoints) | **PUT** /v1/loyalty_programs/{programID}/profile/{integrationID}/add_points | Add points in a certain loyalty program for the specified customer
@@ -283,7 +283,6 @@ Class | Method | HTTP request | Description
 *ManagementApi* | [**getCampaign**](docs/ManagementApi.md#getCampaign) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId} | Get a Campaign
 *ManagementApi* | [**getCampaignAnalytics**](docs/ManagementApi.md#getCampaignAnalytics) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/analytics | Get analytics of campaigns
 *ManagementApi* | [**getCampaignByAttributes**](docs/ManagementApi.md#getCampaignByAttributes) | **POST** /v1/applications/{applicationId}/campaigns_search | Get a list of all campaigns that match the given attributes
-*ManagementApi* | [**getCampaignSet**](docs/ManagementApi.md#getCampaignSet) | **GET** /v1/applications/{applicationId}/campaign_set | List CampaignSet
 *ManagementApi* | [**getCampaigns**](docs/ManagementApi.md#getCampaigns) | **GET** /v1/applications/{applicationId}/campaigns | List your Campaigns
 *ManagementApi* | [**getChanges**](docs/ManagementApi.md#getChanges) | **GET** /v1/changes | Get audit log for an account
 *ManagementApi* | [**getCoupons**](docs/ManagementApi.md#getCoupons) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | List Coupons
@@ -323,7 +322,6 @@ Class | Method | HTTP request | Description
 *ManagementApi* | [**updateAdditionalCost**](docs/ManagementApi.md#updateAdditionalCost) | **PUT** /v1/additional_costs/{additionalCostId} | Update an additional cost
 *ManagementApi* | [**updateAttribute**](docs/ManagementApi.md#updateAttribute) | **PUT** /v1/attributes/{attributeId} | Update a custom attribute
 *ManagementApi* | [**updateCampaign**](docs/ManagementApi.md#updateCampaign) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId} | Update a Campaign
-*ManagementApi* | [**updateCampaignSet**](docs/ManagementApi.md#updateCampaignSet) | **PUT** /v1/applications/{applicationId}/campaign_set | Update a Campaign Set
 *ManagementApi* | [**updateCoupon**](docs/ManagementApi.md#updateCoupon) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons/{couponId} | Update a Coupon
 *ManagementApi* | [**updateCouponBatch**](docs/ManagementApi.md#updateCouponBatch) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | Update a Batch of Coupons
 *ManagementApi* | [**updateRuleset**](docs/ManagementApi.md#updateRuleset) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId}/rulesets/{rulesetId} | Update a Ruleset
@@ -385,6 +383,7 @@ Class | Method | HTTP request | Description
  - [CustomerInventory](docs/CustomerInventory.md)
  - [CustomerProfile](docs/CustomerProfile.md)
  - [CustomerProfileSearchQuery](docs/CustomerProfileSearchQuery.md)
+ - [CustomerProfileUpdate](docs/CustomerProfileUpdate.md)
  - [CustomerSession](docs/CustomerSession.md)
  - [CustomerSessionV2](docs/CustomerSessionV2.md)
  - [DeductLoyaltyPointsEffectProps](docs/DeductLoyaltyPointsEffectProps.md)

--- a/README.md
+++ b/README.md
@@ -124,8 +124,11 @@ public class TalonApiTest {
                     IntegrationRequest.ResponseContentEnum.CUSTOMERPROFILE
                 ));
 
+            // Flag to communicate whether the request is a "dry run"
+            Boolean dryRun = false;
+
             // Create/update a customer session using `updateCustomerSessionV2` function
-            IntegrationStateV2 is = iApi.updateCustomerSessionV2("deetdoot", request);
+            IntegrationStateV2 is = iApi.updateCustomerSessionV2("deetdoot", request, dryRun);
             System.out.println(is.toString());
 
             // Parsing the returned effects list, please consult https://developers.talon.one/Integration-API/handling-effects-v2 for the full list of effects and their corresponding properties
@@ -179,8 +182,11 @@ public class TalonApiTest {
             customerSession.setState(NewCustomerSession.StateEnum.OPEN);
             customerSession.setTotal(new java.math.BigDecimal("42.0"));
 
+            // Flag to communicate whether the request is a "dry run"
+            Boolean dryRun = false;
+
             // Create/update a customer session using `updateCustomerSession` function
-            IntegrationState ie = iApi.updateCustomerSession("deetdoot", customerSession);
+            IntegrationState ie = iApi.updateCustomerSession("deetdoot", customerSession, dryRun);
             System.out.println(ie.toString());
         } catch (Exception e) {
             System.out.println(e);

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'one.talon'
-version = '4.0.0'
+version = '4.1.0'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "one.talon",
     name := "talon-one-client",
-    version := "4.0.0",
+    version := "4.1.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/docs/Application.md
+++ b/docs/Application.md
@@ -18,6 +18,7 @@ Name | Type | Description | Notes
 **caseSensitivity** | [**CaseSensitivityEnum**](#CaseSensitivityEnum) | A string indicating how should campaigns in this application deal with case sensitivity on coupon codes. |  [optional]
 **attributes** | [**Object**](.md) | Arbitrary properties associated with this campaign |  [optional]
 **limits** | [**List&lt;LimitConfig&gt;**](LimitConfig.md) | Default limits for campaigns created in this application |  [optional]
+**campaignPriority** | [**CampaignPriorityEnum**](#CampaignPriorityEnum) | Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive) |  [optional]
 **attributesSettings** | [**AttributesSettings**](AttributesSettings.md) |  |  [optional]
 **loyaltyPrograms** | [**List&lt;LoyaltyProgram&gt;**](LoyaltyProgram.md) | An array containing all the loyalty programs to which this application is subscribed | 
 
@@ -30,6 +31,16 @@ Name | Value
 SENSITIVE | &quot;sensitive&quot;
 INSENSITIVE_UPPERCASE | &quot;insensitive-uppercase&quot;
 INSENSITIVE_LOWERCASE | &quot;insensitive-lowercase&quot;
+
+
+
+## Enum: CampaignPriorityEnum
+
+Name | Value
+---- | -----
+UNIVERSAL | &quot;universal&quot;
+STACKABLE | &quot;stackable&quot;
+EXCLUSIVE | &quot;exclusive&quot;
 
 
 

--- a/docs/ApplicationSession.md
+++ b/docs/ApplicationSession.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **state** | [**StateEnum**](#StateEnum) | Indicating if the customer session is in progress (\&quot;open\&quot;), \&quot;closed\&quot;, or \&quot;cancelled\&quot;. | 
 **cartItems** | [**List&lt;CartItem&gt;**](CartItem.md) | Serialized JSON representation. | 
 **discounts** | [**Map&lt;String, BigDecimal&gt;**](BigDecimal.md) | A map of labelled discount values, in the same currency as the session. | 
-**total** | [**BigDecimal**](BigDecimal.md) | The total sum of the session before any discounts applied. |  [optional]
+**total** | [**BigDecimal**](BigDecimal.md) | The total sum of the session before any discounts applied. | 
 **attributes** | [**Object**](.md) | Arbitrary properties associated with this item |  [optional]
 
 

--- a/docs/CampaignSet.md
+++ b/docs/CampaignSet.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **id** | **Integer** | Unique ID for this entity. | 
 **created** | [**OffsetDateTime**](OffsetDateTime.md) | The exact moment this entity was created. | 
 **applicationId** | **Integer** | The ID of the application that owns this entity. | 
+**version** | **Integer** | Version of the campaign set | 
 **set** | [**CampaignSetBranchNode**](CampaignSetBranchNode.md) |  | 
 
 

--- a/docs/Coupon.md
+++ b/docs/Coupon.md
@@ -12,12 +12,15 @@ Name | Type | Description | Notes
 **campaignId** | **Integer** | The ID of the campaign that owns this entity. | 
 **value** | **String** | The actual coupon code. | 
 **usageLimit** | **Integer** | The number of times a coupon code can be redeemed. This can be set to 0 for no limit, but any campaign usage limits will still apply.  | 
+**discountLimit** | [**BigDecimal**](BigDecimal.md) | The amount of discounts that can be given with this coupon code.  |  [optional]
 **startDate** | [**OffsetDateTime**](OffsetDateTime.md) | Timestamp at which point the coupon becomes valid. |  [optional]
 **expiryDate** | [**OffsetDateTime**](OffsetDateTime.md) | Expiry date of the coupon. Coupon never expires if this is omitted, zero, or negative. |  [optional]
 **usageCounter** | **Integer** | The number of times this coupon has been successfully used. | 
+**discountCounter** | [**BigDecimal**](BigDecimal.md) | The amount of discounts given on rules redeeming this coupon. Only usable if a coupon discount budget was set for this coupon. |  [optional]
+**discountRemainder** | [**BigDecimal**](BigDecimal.md) | The remaining discount this coupon can give. |  [optional]
 **attributes** | [**Object**](.md) | Arbitrary properties associated with this item |  [optional]
 **referralId** | **Integer** | The integration ID of the referring customer (if any) for whom this coupon was created as an effect. |  [optional]
-**recipientIntegrationId** | **String** | The integration ID of a referred customer profile. |  [optional]
+**recipientIntegrationId** | **String** | The Integration ID of the customer that is allowed to redeem this coupon. |  [optional]
 **importId** | **Integer** | The ID of the Import which created this coupon. |  [optional]
 **reservation** | **Boolean** | This value controls what reservations mean to a coupon. If set to true the coupon reservation is used to mark it as a favourite, if set to false the coupon reservation is used as a requirement of usage. This value defaults to true if not specified. |  [optional]
 **batchId** | **String** | The id of the batch the coupon belongs to. |  [optional]

--- a/docs/CouponConstraints.md
+++ b/docs/CouponConstraints.md
@@ -7,6 +7,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **usageLimit** | **Integer** | The number of times a coupon code can be redeemed. This can be set to 0 for no limit, but any campaign usage limits will still apply.  |  [optional]
+**discountLimit** | [**BigDecimal**](BigDecimal.md) | The amount of discounts that can be given with this coupon code.  |  [optional]
 **startDate** | [**OffsetDateTime**](OffsetDateTime.md) | Timestamp at which point the coupon becomes valid. |  [optional]
 **expiryDate** | [**OffsetDateTime**](OffsetDateTime.md) | Expiry date of the coupon. Coupon never expires if this is omitted, zero, or negative. |  [optional]
 

--- a/docs/CustomerInventory.md
+++ b/docs/CustomerInventory.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **profile** | [**CustomerProfile**](CustomerProfile.md) |  |  [optional]
 **referrals** | [**List&lt;Referral&gt;**](Referral.md) |  |  [optional]
+**coupons** | [**List&lt;Coupon&gt;**](Coupon.md) |  |  [optional]
 
 
 

--- a/docs/CustomerProfileUpdate.md
+++ b/docs/CustomerProfileUpdate.md
@@ -1,13 +1,12 @@
 
 
-# InlineResponse2003
+# CustomerProfileUpdate
 
 ## Properties
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**totalResultSize** | **Integer** |  | 
-**data** | [**List&lt;Ruleset&gt;**](Ruleset.md) |  | 
+**customerProfile** | [**CustomerProfile**](CustomerProfile.md) |  | 
 
 
 

--- a/docs/InlineResponse2001.md
+++ b/docs/InlineResponse2001.md
@@ -7,7 +7,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **totalResultSize** | **Integer** |  | 
-**data** | [**List&lt;Coupon&gt;**](Coupon.md) |  | 
+**data** | [**List&lt;Application&gt;**](Application.md) |  | 
 
 
 

--- a/docs/InlineResponse2002.md
+++ b/docs/InlineResponse2002.md
@@ -7,7 +7,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **totalResultSize** | **Integer** |  | 
-**data** | [**List&lt;Application&gt;**](Application.md) |  | 
+**data** | [**List&lt;Campaign&gt;**](Campaign.md) |  | 
 
 
 

--- a/docs/InlineResponse2004.md
+++ b/docs/InlineResponse2004.md
@@ -7,7 +7,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **totalResultSize** | **Integer** |  | 
-**data** | [**List&lt;Ruleset&gt;**](Ruleset.md) |  | 
+**data** | [**List&lt;Coupon&gt;**](Coupon.md) |  | 
 
 
 

--- a/docs/IntegrationApi.md
+++ b/docs/IntegrationApi.md
@@ -9,10 +9,10 @@ Method | HTTP request | Description
 [**deleteCouponReservation**](IntegrationApi.md#deleteCouponReservation) | **DELETE** /v1/coupon_reservations/{couponValue} | Delete coupon reservations
 [**deleteCustomerData**](IntegrationApi.md#deleteCustomerData) | **DELETE** /v1/customer_data/{integrationId} | Delete the personal data of a customer.
 [**getCustomerInventory**](IntegrationApi.md#getCustomerInventory) | **GET** /v1/customer_profiles/{integrationId}/inventory | Get an inventory of all data associated with a specific customer profile.
-[**getReservedCoupons**](IntegrationApi.md#getReservedCoupons) | **GET** /v1/coupon_reservations/coupons/{integrationId} | Get all valid reserved coupons
 [**getReservedCustomers**](IntegrationApi.md#getReservedCustomers) | **GET** /v1/coupon_reservations/customerprofiles/{couponValue} | Get the users that have this coupon reserved
 [**trackEvent**](IntegrationApi.md#trackEvent) | **POST** /v1/events | Track an Event
 [**updateCustomerProfile**](IntegrationApi.md#updateCustomerProfile) | **PUT** /v1/customer_profiles/{integrationId} | Update a Customer Profile
+[**updateCustomerProfileV2**](IntegrationApi.md#updateCustomerProfileV2) | **PUT** /v2/customer_profiles/{customerProfileId} | Update a Customer Profile
 [**updateCustomerSession**](IntegrationApi.md#updateCustomerSession) | **PUT** /v1/customer_sessions/{customerSessionId} | Update a Customer Session
 [**updateCustomerSessionV2**](IntegrationApi.md#updateCustomerSessionV2) | **PUT** /v2/customer_sessions/{customerSessionId} | Update a Customer Session
 
@@ -321,11 +321,11 @@ null (empty response body)
 
 <a name="getCustomerInventory"></a>
 # **getCustomerInventory**
-> CustomerInventory getCustomerInventory(integrationId, profile, referrals)
+> CustomerInventory getCustomerInventory(integrationId, profile, referrals, coupons)
 
 Get an inventory of all data associated with a specific customer profile.
 
-Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information and referral codes. In the future, this will be expanded with coupon codes and loyalty points.
+Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information, referral codes and reserved coupons. In the future, this will be expanded with loyalty points.
 
 ### Example
 ```java
@@ -356,10 +356,11 @@ public class Example {
 
     IntegrationApi apiInstance = new IntegrationApi(defaultClient);
     String integrationId = "integrationId_example"; // String | The custom identifier for this profile, must be unique within the account.
-    Object profile = null; // Object | optional flag to decide if you would like customer profile information in the response
-    Object referrals = null; // Object | optional flag to decide if you would like referral information in the response
+    Boolean profile = true; // Boolean | optional flag to decide if you would like customer profile information in the response
+    Boolean referrals = true; // Boolean | optional flag to decide if you would like referral information in the response
+    Boolean coupons = true; // Boolean | optional flag to decide if you would like coupon information in the response
     try {
-      CustomerInventory result = apiInstance.getCustomerInventory(integrationId, profile, referrals);
+      CustomerInventory result = apiInstance.getCustomerInventory(integrationId, profile, referrals, coupons);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling IntegrationApi#getCustomerInventory");
@@ -377,87 +378,13 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **integrationId** | **String**| The custom identifier for this profile, must be unique within the account. |
- **profile** | [**Object**](.md)| optional flag to decide if you would like customer profile information in the response | [optional] [default to null]
- **referrals** | [**Object**](.md)| optional flag to decide if you would like referral information in the response | [optional] [default to null]
+ **profile** | **Boolean**| optional flag to decide if you would like customer profile information in the response | [optional]
+ **referrals** | **Boolean**| optional flag to decide if you would like referral information in the response | [optional]
+ **coupons** | **Boolean**| optional flag to decide if you would like coupon information in the response | [optional]
 
 ### Return type
 
 [**CustomerInventory**](CustomerInventory.md)
-
-### Authorization
-
-[api_key_v1](../README.md#api_key_v1), [integration_auth](../README.md#integration_auth)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | OK |  -  |
-
-<a name="getReservedCoupons"></a>
-# **getReservedCoupons**
-> InlineResponse2001 getReservedCoupons(integrationId)
-
-Get all valid reserved coupons
-
-Returns all coupons this user is subscribed to that are valid and usable 
-
-### Example
-```java
-// Import classes:
-import one.talon.ApiClient;
-import one.talon.ApiException;
-import one.talon.Configuration;
-import one.talon.auth.*;
-import one.talon.models.*;
-import one.talon.api.IntegrationApi;
-
-public class Example {
-  public static void main(String[] args) {
-    ApiClient defaultClient = Configuration.getDefaultApiClient();
-    defaultClient.setBasePath("http://localhost");
-    
-    // Configure API key authorization: api_key_v1
-    ApiKeyAuth api_key_v1 = (ApiKeyAuth) defaultClient.getAuthentication("api_key_v1");
-    api_key_v1.setApiKey("YOUR API KEY");
-    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-    //api_key_v1.setApiKeyPrefix("Token");
-
-    // Configure API key authorization: integration_auth
-    ApiKeyAuth integration_auth = (ApiKeyAuth) defaultClient.getAuthentication("integration_auth");
-    integration_auth.setApiKey("YOUR API KEY");
-    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-    //integration_auth.setApiKeyPrefix("Token");
-
-    IntegrationApi apiInstance = new IntegrationApi(defaultClient);
-    String integrationId = "integrationId_example"; // String | The custom identifier for this profile, must be unique within the account.
-    try {
-      InlineResponse2001 result = apiInstance.getReservedCoupons(integrationId);
-      System.out.println(result);
-    } catch (ApiException e) {
-      System.err.println("Exception when calling IntegrationApi#getReservedCoupons");
-      System.err.println("Status code: " + e.getCode());
-      System.err.println("Reason: " + e.getResponseBody());
-      System.err.println("Response headers: " + e.getResponseHeaders());
-      e.printStackTrace();
-    }
-  }
-}
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **integrationId** | **String**| The custom identifier for this profile, must be unique within the account. |
-
-### Return type
-
-[**InlineResponse2001**](InlineResponse2001.md)
 
 ### Authorization
 
@@ -550,7 +477,7 @@ Name | Type | Description  | Notes
 
 <a name="trackEvent"></a>
 # **trackEvent**
-> IntegrationState trackEvent(body)
+> IntegrationState trackEvent(body, dry)
 
 Track an Event
 
@@ -585,8 +512,9 @@ public class Example {
 
     IntegrationApi apiInstance = new IntegrationApi(defaultClient);
     NewEvent body = new NewEvent(); // NewEvent | 
+    Boolean dry = true; // Boolean | Flag to indicate whether to skip persisting the changes or not (Will not persist if set to 'true').
     try {
-      IntegrationState result = apiInstance.trackEvent(body);
+      IntegrationState result = apiInstance.trackEvent(body, dry);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling IntegrationApi#trackEvent");
@@ -604,6 +532,7 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**NewEvent**](NewEvent.md)|  |
+ **dry** | **Boolean**| Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). | [optional]
 
 ### Return type
 
@@ -625,7 +554,7 @@ Name | Type | Description  | Notes
 
 <a name="updateCustomerProfile"></a>
 # **updateCustomerProfile**
-> IntegrationState updateCustomerProfile(integrationId, body)
+> IntegrationState updateCustomerProfile(integrationId, body, dry)
 
 Update a Customer Profile
 
@@ -661,8 +590,9 @@ public class Example {
     IntegrationApi apiInstance = new IntegrationApi(defaultClient);
     String integrationId = "integrationId_example"; // String | The custom identifier for this profile, must be unique within the account.
     NewCustomerProfile body = new NewCustomerProfile(); // NewCustomerProfile | 
+    Boolean dry = true; // Boolean | Flag to indicate whether to skip persisting the changes or not (Will not persist if set to 'true').
     try {
-      IntegrationState result = apiInstance.updateCustomerProfile(integrationId, body);
+      IntegrationState result = apiInstance.updateCustomerProfile(integrationId, body, dry);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling IntegrationApi#updateCustomerProfile");
@@ -681,6 +611,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **integrationId** | **String**| The custom identifier for this profile, must be unique within the account. |
  **body** | [**NewCustomerProfile**](NewCustomerProfile.md)|  |
+ **dry** | **Boolean**| Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). | [optional]
 
 ### Return type
 
@@ -700,9 +631,80 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 
+<a name="updateCustomerProfileV2"></a>
+# **updateCustomerProfileV2**
+> CustomerProfileUpdate updateCustomerProfileV2(customerProfileId, body)
+
+Update a Customer Profile
+
+Update (or create) a [Customer Profile][].   The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  [Customer Profile]: /Getting-Started/entities#customer-profile 
+
+### Example
+```java
+// Import classes:
+import one.talon.ApiClient;
+import one.talon.ApiException;
+import one.talon.Configuration;
+import one.talon.auth.*;
+import one.talon.models.*;
+import one.talon.api.IntegrationApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost");
+    
+    // Configure API key authorization: api_key_v1
+    ApiKeyAuth api_key_v1 = (ApiKeyAuth) defaultClient.getAuthentication("api_key_v1");
+    api_key_v1.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //api_key_v1.setApiKeyPrefix("Token");
+
+    IntegrationApi apiInstance = new IntegrationApi(defaultClient);
+    String customerProfileId = "customerProfileId_example"; // String | The custom identifier for this profile, must be unique within the account.
+    NewCustomerProfile body = new NewCustomerProfile(); // NewCustomerProfile | 
+    try {
+      CustomerProfileUpdate result = apiInstance.updateCustomerProfileV2(customerProfileId, body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling IntegrationApi#updateCustomerProfileV2");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **customerProfileId** | **String**| The custom identifier for this profile, must be unique within the account. |
+ **body** | [**NewCustomerProfile**](NewCustomerProfile.md)|  |
+
+### Return type
+
+[**CustomerProfileUpdate**](CustomerProfileUpdate.md)
+
+### Authorization
+
+[api_key_v1](../README.md#api_key_v1)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | OK |  -  |
+
 <a name="updateCustomerSession"></a>
 # **updateCustomerSession**
-> IntegrationState updateCustomerSession(customerSessionId, body)
+> IntegrationState updateCustomerSession(customerSessionId, body, dry)
 
 Update a Customer Session
 
@@ -738,8 +740,9 @@ public class Example {
     IntegrationApi apiInstance = new IntegrationApi(defaultClient);
     String customerSessionId = "customerSessionId_example"; // String | The custom identifier for this session, must be unique within the account.
     NewCustomerSession body = new NewCustomerSession(); // NewCustomerSession | 
+    Boolean dry = true; // Boolean | Flag to indicate whether to skip persisting the changes or not (Will not persist if set to 'true').
     try {
-      IntegrationState result = apiInstance.updateCustomerSession(customerSessionId, body);
+      IntegrationState result = apiInstance.updateCustomerSession(customerSessionId, body, dry);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling IntegrationApi#updateCustomerSession");
@@ -758,6 +761,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **customerSessionId** | **String**| The custom identifier for this session, must be unique within the account. |
  **body** | [**NewCustomerSession**](NewCustomerSession.md)|  |
+ **dry** | **Boolean**| Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). | [optional]
 
 ### Return type
 
@@ -779,7 +783,7 @@ Name | Type | Description  | Notes
 
 <a name="updateCustomerSessionV2"></a>
 # **updateCustomerSessionV2**
-> IntegrationStateV2 updateCustomerSessionV2(customerSessionId, body)
+> IntegrationStateV2 updateCustomerSessionV2(customerSessionId, body, dry)
 
 Update a Customer Session
 
@@ -809,8 +813,9 @@ public class Example {
     IntegrationApi apiInstance = new IntegrationApi(defaultClient);
     String customerSessionId = "customerSessionId_example"; // String | The custom identifier for this session, must be unique within the account.
     IntegrationRequest body = new IntegrationRequest(); // IntegrationRequest | 
+    Boolean dry = true; // Boolean | Flag to indicate whether to skip persisting the changes or not (Will not persist if set to 'true').
     try {
-      IntegrationStateV2 result = apiInstance.updateCustomerSessionV2(customerSessionId, body);
+      IntegrationStateV2 result = apiInstance.updateCustomerSessionV2(customerSessionId, body, dry);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling IntegrationApi#updateCustomerSessionV2");
@@ -829,6 +834,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **customerSessionId** | **String**| The custom identifier for this session, must be unique within the account. |
  **body** | [**IntegrationRequest**](IntegrationRequest.md)|  |
+ **dry** | **Boolean**| Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). | [optional]
 
 ### Return type
 

--- a/docs/LoyaltyLedgerEntry.md
+++ b/docs/LoyaltyLedgerEntry.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **expiryDate** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **name** | **String** | A name referencing the condition or effect that added this entry, or the specific name provided in an API call. | 
 **subLedgerID** | **String** | This specifies if we are adding loyalty points to the main ledger or a subledger | 
+**userID** | **Integer** | This is the ID of the user who created this entry, if the addition or subtraction was done manually. |  [optional]
 
 
 

--- a/docs/ManagementApi.md
+++ b/docs/ManagementApi.md
@@ -42,7 +42,6 @@ Method | HTTP request | Description
 [**getCampaign**](ManagementApi.md#getCampaign) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId} | Get a Campaign
 [**getCampaignAnalytics**](ManagementApi.md#getCampaignAnalytics) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/analytics | Get analytics of campaigns
 [**getCampaignByAttributes**](ManagementApi.md#getCampaignByAttributes) | **POST** /v1/applications/{applicationId}/campaigns_search | Get a list of all campaigns that match the given attributes
-[**getCampaignSet**](ManagementApi.md#getCampaignSet) | **GET** /v1/applications/{applicationId}/campaign_set | List CampaignSet
 [**getCampaigns**](ManagementApi.md#getCampaigns) | **GET** /v1/applications/{applicationId}/campaigns | List your Campaigns
 [**getChanges**](ManagementApi.md#getChanges) | **GET** /v1/changes | Get audit log for an account
 [**getCoupons**](ManagementApi.md#getCoupons) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | List Coupons
@@ -82,7 +81,6 @@ Method | HTTP request | Description
 [**updateAdditionalCost**](ManagementApi.md#updateAdditionalCost) | **PUT** /v1/additional_costs/{additionalCostId} | Update an additional cost
 [**updateAttribute**](ManagementApi.md#updateAttribute) | **PUT** /v1/attributes/{attributeId} | Update a custom attribute
 [**updateCampaign**](ManagementApi.md#updateCampaign) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId} | Update a Campaign
-[**updateCampaignSet**](ManagementApi.md#updateCampaignSet) | **PUT** /v1/applications/{applicationId}/campaign_set | Update a Campaign Set
 [**updateCoupon**](ManagementApi.md#updateCoupon) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons/{couponId} | Update a Coupon
 [**updateCouponBatch**](ManagementApi.md#updateCouponBatch) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | Update a Batch of Coupons
 [**updateRuleset**](ManagementApi.md#updateRuleset) | **PUT** /v1/applications/{applicationId}/campaigns/{campaignId}/rulesets/{rulesetId} | Update a Ruleset
@@ -160,7 +158,7 @@ null (empty response body)
 
 <a name="copyCampaignToApplications"></a>
 # **copyCampaignToApplications**
-> InlineResponse2003 copyCampaignToApplications(applicationId, campaignId, body)
+> InlineResponse2002 copyCampaignToApplications(applicationId, campaignId, body)
 
 Copy the campaign into every specified application
 
@@ -192,7 +190,7 @@ public class Example {
     Integer campaignId = 56; // Integer | 
     CampaignCopy body = new CampaignCopy(); // CampaignCopy | 
     try {
-      InlineResponse2003 result = apiInstance.copyCampaignToApplications(applicationId, campaignId, body);
+      InlineResponse2002 result = apiInstance.copyCampaignToApplications(applicationId, campaignId, body);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#copyCampaignToApplications");
@@ -215,7 +213,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2003**](InlineResponse2003.md)
+[**InlineResponse2002**](InlineResponse2002.md)
 
 ### Authorization
 
@@ -440,7 +438,7 @@ Name | Type | Description  | Notes
 
 <a name="createCoupons"></a>
 # **createCoupons**
-> InlineResponse2001 createCoupons(applicationId, campaignId, body, silent)
+> InlineResponse2004 createCoupons(applicationId, campaignId, body, silent)
 
 Create Coupons
 
@@ -473,7 +471,7 @@ public class Example {
     NewCoupons body = new NewCoupons(); // NewCoupons | 
     String silent = "silent_example"; // String | If set to 'yes', response will be an empty 204, otherwise a list of the coupons generated (to to 1000).
     try {
-      InlineResponse2001 result = apiInstance.createCoupons(applicationId, campaignId, body, silent);
+      InlineResponse2004 result = apiInstance.createCoupons(applicationId, campaignId, body, silent);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#createCoupons");
@@ -497,7 +495,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2001**](InlineResponse2001.md)
+[**InlineResponse2004**](InlineResponse2004.md)
 
 ### Authorization
 
@@ -2451,7 +2449,7 @@ Name | Type | Description  | Notes
 
 <a name="getApplications"></a>
 # **getApplications**
-> InlineResponse2002 getApplications(pageSize, skip, sort)
+> InlineResponse2001 getApplications(pageSize, skip, sort)
 
 List Applications
 
@@ -2483,7 +2481,7 @@ public class Example {
     Integer skip = 56; // Integer | Skips the given number of items when paging through large result sets.
     String sort = "sort_example"; // String | The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with `-` to sort in descending order.
     try {
-      InlineResponse2002 result = apiInstance.getApplications(pageSize, skip, sort);
+      InlineResponse2001 result = apiInstance.getApplications(pageSize, skip, sort);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#getApplications");
@@ -2506,7 +2504,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2002**](InlineResponse2002.md)
+[**InlineResponse2001**](InlineResponse2001.md)
 
 ### Authorization
 
@@ -2810,7 +2808,7 @@ Name | Type | Description  | Notes
 
 <a name="getCampaignByAttributes"></a>
 # **getCampaignByAttributes**
-> InlineResponse2003 getCampaignByAttributes(applicationId, body, pageSize, skip, sort, campaignState)
+> InlineResponse2002 getCampaignByAttributes(applicationId, body, pageSize, skip, sort, campaignState)
 
 Get a list of all campaigns that match the given attributes
 
@@ -2845,7 +2843,7 @@ public class Example {
     String sort = "sort_example"; // String | The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with `-` to sort in descending order.
     String campaignState = "campaignState_example"; // String | Filter results by the state of the campaign.
     try {
-      InlineResponse2003 result = apiInstance.getCampaignByAttributes(applicationId, body, pageSize, skip, sort, campaignState);
+      InlineResponse2002 result = apiInstance.getCampaignByAttributes(applicationId, body, pageSize, skip, sort, campaignState);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#getCampaignByAttributes");
@@ -2871,7 +2869,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2003**](InlineResponse2003.md)
+[**InlineResponse2002**](InlineResponse2002.md)
 
 ### Authorization
 
@@ -2887,76 +2885,9 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 
-<a name="getCampaignSet"></a>
-# **getCampaignSet**
-> CampaignSet getCampaignSet(applicationId)
-
-List CampaignSet
-
-### Example
-```java
-// Import classes:
-import one.talon.ApiClient;
-import one.talon.ApiException;
-import one.talon.Configuration;
-import one.talon.auth.*;
-import one.talon.models.*;
-import one.talon.api.ManagementApi;
-
-public class Example {
-  public static void main(String[] args) {
-    ApiClient defaultClient = Configuration.getDefaultApiClient();
-    defaultClient.setBasePath("http://localhost");
-    
-    // Configure API key authorization: manager_auth
-    ApiKeyAuth manager_auth = (ApiKeyAuth) defaultClient.getAuthentication("manager_auth");
-    manager_auth.setApiKey("YOUR API KEY");
-    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-    //manager_auth.setApiKeyPrefix("Token");
-
-    ManagementApi apiInstance = new ManagementApi(defaultClient);
-    Integer applicationId = 56; // Integer | 
-    try {
-      CampaignSet result = apiInstance.getCampaignSet(applicationId);
-      System.out.println(result);
-    } catch (ApiException e) {
-      System.err.println("Exception when calling ManagementApi#getCampaignSet");
-      System.err.println("Status code: " + e.getCode());
-      System.err.println("Reason: " + e.getResponseBody());
-      System.err.println("Response headers: " + e.getResponseHeaders());
-      e.printStackTrace();
-    }
-  }
-}
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **applicationId** | **Integer**|  |
-
-### Return type
-
-[**CampaignSet**](CampaignSet.md)
-
-### Authorization
-
-[manager_auth](../README.md#manager_auth)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | OK |  -  |
-
 <a name="getCampaigns"></a>
 # **getCampaigns**
-> InlineResponse2003 getCampaigns(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter)
+> InlineResponse2002 getCampaigns(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter)
 
 List your Campaigns
 
@@ -2992,7 +2923,7 @@ public class Example {
     OffsetDateTime createdBefore = new OffsetDateTime(); // OffsetDateTime | Filter results comparing the parameter value, expected to be an RFC3339 timestamp string, to the campaign creation timestamp.
     OffsetDateTime createdAfter = new OffsetDateTime(); // OffsetDateTime | Filter results comparing the parameter value, expected to be an RFC3339 timestamp string, to the campaign creation timestamp.
     try {
-      InlineResponse2003 result = apiInstance.getCampaigns(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter);
+      InlineResponse2002 result = apiInstance.getCampaigns(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#getCampaigns");
@@ -3021,7 +2952,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2003**](InlineResponse2003.md)
+[**InlineResponse2002**](InlineResponse2002.md)
 
 ### Authorization
 
@@ -3122,7 +3053,7 @@ Name | Type | Description  | Notes
 
 <a name="getCoupons"></a>
 # **getCoupons**
-> InlineResponse2001 getCoupons(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch)
+> InlineResponse2004 getCoupons(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch)
 
 List Coupons
 
@@ -3167,7 +3098,7 @@ public class Example {
     String recipientIntegrationId = "recipientIntegrationId_example"; // String | Filter results by match with a profile id specified in the coupon's RecipientIntegrationId field
     Boolean exactMatch = false; // Boolean | Filter results to an exact case-insensitive matching against the coupon code
     try {
-      InlineResponse2001 result = apiInstance.getCoupons(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch);
+      InlineResponse2004 result = apiInstance.getCoupons(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#getCoupons");
@@ -3205,7 +3136,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2001**](InlineResponse2001.md)
+[**InlineResponse2004**](InlineResponse2004.md)
 
 ### Authorization
 
@@ -3223,7 +3154,7 @@ Name | Type | Description  | Notes
 
 <a name="getCouponsByAttributes"></a>
 # **getCouponsByAttributes**
-> InlineResponse2001 getCouponsByAttributes(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId)
+> InlineResponse2004 getCouponsByAttributes(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId)
 
 Get a list of the coupons that match the given attributes
 
@@ -3267,7 +3198,7 @@ public class Example {
     Boolean exactMatch = false; // Boolean | Filter results to an exact case-insensitive matching against the coupon code
     String batchId = "batchId_example"; // String | Filter results by batches of coupons
     try {
-      InlineResponse2001 result = apiInstance.getCouponsByAttributes(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
+      InlineResponse2004 result = apiInstance.getCouponsByAttributes(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#getCouponsByAttributes");
@@ -3302,7 +3233,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2001**](InlineResponse2001.md)
+[**InlineResponse2004**](InlineResponse2004.md)
 
 ### Authorization
 
@@ -3320,7 +3251,7 @@ Name | Type | Description  | Notes
 
 <a name="getCouponsByAttributesApplicationWide"></a>
 # **getCouponsByAttributesApplicationWide**
-> InlineResponse2001 getCouponsByAttributesApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState)
+> InlineResponse2004 getCouponsByAttributesApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState)
 
 Get a list of the coupons that match the given attributes in all active campaigns of an application
 
@@ -3364,7 +3295,7 @@ public class Example {
     Boolean exactMatch = false; // Boolean | Filter results to an exact case-insensitive matching against the coupon code
     String campaignState = "campaignState_example"; // String | Filter results by the state of the campaign.
     try {
-      InlineResponse2001 result = apiInstance.getCouponsByAttributesApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
+      InlineResponse2004 result = apiInstance.getCouponsByAttributesApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#getCouponsByAttributesApplicationWide");
@@ -3399,7 +3330,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2001**](InlineResponse2001.md)
+[**InlineResponse2004**](InlineResponse2004.md)
 
 ### Authorization
 
@@ -4791,7 +4722,7 @@ Name | Type | Description  | Notes
 
 <a name="getRulesets"></a>
 # **getRulesets**
-> InlineResponse2004 getRulesets(applicationId, campaignId, pageSize, skip, sort)
+> InlineResponse2003 getRulesets(applicationId, campaignId, pageSize, skip, sort)
 
 List Campaign Rulesets
 
@@ -4823,7 +4754,7 @@ public class Example {
     Integer skip = 56; // Integer | Skips the given number of items when paging through large result sets.
     String sort = "sort_example"; // String | The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with `-` to sort in descending order.
     try {
-      InlineResponse2004 result = apiInstance.getRulesets(applicationId, campaignId, pageSize, skip, sort);
+      InlineResponse2003 result = apiInstance.getRulesets(applicationId, campaignId, pageSize, skip, sort);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#getRulesets");
@@ -4848,7 +4779,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2004**](InlineResponse2004.md)
+[**InlineResponse2003**](InlineResponse2003.md)
 
 ### Authorization
 
@@ -5459,7 +5390,7 @@ Name | Type | Description  | Notes
 
 <a name="searchCouponsAdvanced"></a>
 # **searchCouponsAdvanced**
-> InlineResponse2001 searchCouponsAdvanced(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId)
+> InlineResponse2004 searchCouponsAdvanced(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId)
 
 Get a list of the coupons that match the given attributes
 
@@ -5503,7 +5434,7 @@ public class Example {
     Boolean exactMatch = false; // Boolean | Filter results to an exact case-insensitive matching against the coupon code
     String batchId = "batchId_example"; // String | Filter results by batches of coupons
     try {
-      InlineResponse2001 result = apiInstance.searchCouponsAdvanced(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
+      InlineResponse2004 result = apiInstance.searchCouponsAdvanced(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#searchCouponsAdvanced");
@@ -5538,7 +5469,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2001**](InlineResponse2001.md)
+[**InlineResponse2004**](InlineResponse2004.md)
 
 ### Authorization
 
@@ -5556,7 +5487,7 @@ Name | Type | Description  | Notes
 
 <a name="searchCouponsAdvancedApplicationWide"></a>
 # **searchCouponsAdvancedApplicationWide**
-> InlineResponse2001 searchCouponsAdvancedApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState)
+> InlineResponse2004 searchCouponsAdvancedApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState)
 
 Get a list of the coupons that match the given attributes in all active campaigns of an application
 
@@ -5600,7 +5531,7 @@ public class Example {
     Boolean exactMatch = false; // Boolean | Filter results to an exact case-insensitive matching against the coupon code
     String campaignState = "campaignState_example"; // String | Filter results by the state of the campaign.
     try {
-      InlineResponse2001 result = apiInstance.searchCouponsAdvancedApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
+      InlineResponse2004 result = apiInstance.searchCouponsAdvancedApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ManagementApi#searchCouponsAdvancedApplicationWide");
@@ -5635,7 +5566,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**InlineResponse2001**](InlineResponse2001.md)
+[**InlineResponse2004**](InlineResponse2004.md)
 
 ### Authorization
 
@@ -6043,75 +5974,6 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**Campaign**](Campaign.md)
-
-### Authorization
-
-[manager_auth](../README.md#manager_auth)
-
-### HTTP request headers
-
- - **Content-Type**: application/json
- - **Accept**: application/json
-
-### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | OK |  -  |
-
-<a name="updateCampaignSet"></a>
-# **updateCampaignSet**
-> CampaignSet updateCampaignSet(applicationId, body)
-
-Update a Campaign Set
-
-### Example
-```java
-// Import classes:
-import one.talon.ApiClient;
-import one.talon.ApiException;
-import one.talon.Configuration;
-import one.talon.auth.*;
-import one.talon.models.*;
-import one.talon.api.ManagementApi;
-
-public class Example {
-  public static void main(String[] args) {
-    ApiClient defaultClient = Configuration.getDefaultApiClient();
-    defaultClient.setBasePath("http://localhost");
-    
-    // Configure API key authorization: manager_auth
-    ApiKeyAuth manager_auth = (ApiKeyAuth) defaultClient.getAuthentication("manager_auth");
-    manager_auth.setApiKey("YOUR API KEY");
-    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-    //manager_auth.setApiKeyPrefix("Token");
-
-    ManagementApi apiInstance = new ManagementApi(defaultClient);
-    Integer applicationId = 56; // Integer | 
-    NewCampaignSet body = new NewCampaignSet(); // NewCampaignSet | 
-    try {
-      CampaignSet result = apiInstance.updateCampaignSet(applicationId, body);
-      System.out.println(result);
-    } catch (ApiException e) {
-      System.err.println("Exception when calling ManagementApi#updateCampaignSet");
-      System.err.println("Status code: " + e.getCode());
-      System.err.println("Reason: " + e.getResponseBody());
-      System.err.println("Response headers: " + e.getResponseHeaders());
-      e.printStackTrace();
-    }
-  }
-}
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **applicationId** | **Integer**|  |
- **body** | [**NewCampaignSet**](NewCampaignSet.md)|  |
-
-### Return type
-
-[**CampaignSet**](CampaignSet.md)
 
 ### Authorization
 

--- a/docs/NewApplication.md
+++ b/docs/NewApplication.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **caseSensitivity** | [**CaseSensitivityEnum**](#CaseSensitivityEnum) | A string indicating how should campaigns in this application deal with case sensitivity on coupon codes. |  [optional]
 **attributes** | [**Object**](.md) | Arbitrary properties associated with this campaign |  [optional]
 **limits** | [**List&lt;LimitConfig&gt;**](LimitConfig.md) | Default limits for campaigns created in this application |  [optional]
+**campaignPriority** | [**CampaignPriorityEnum**](#CampaignPriorityEnum) | Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive) |  [optional]
 **attributesSettings** | [**AttributesSettings**](AttributesSettings.md) |  |  [optional]
 **key** | **String** | Hex key for HMAC-signing API calls as coming from this application (16 hex digits) |  [optional]
 
@@ -26,6 +27,16 @@ Name | Value
 SENSITIVE | &quot;sensitive&quot;
 INSENSITIVE_UPPERCASE | &quot;insensitive-uppercase&quot;
 INSENSITIVE_LOWERCASE | &quot;insensitive-lowercase&quot;
+
+
+
+## Enum: CampaignPriorityEnum
+
+Name | Value
+---- | -----
+UNIVERSAL | &quot;universal&quot;
+STACKABLE | &quot;stackable&quot;
+EXCLUSIVE | &quot;exclusive&quot;
 
 
 

--- a/docs/NewCampaignSet.md
+++ b/docs/NewCampaignSet.md
@@ -8,6 +8,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **applicationId** | **Integer** | The ID of the application that owns this entity. | 
+**version** | **Integer** | Version of the campaign set | 
 **set** | [**CampaignSetBranchNode**](CampaignSetBranchNode.md) |  | 
 
 

--- a/docs/NewCoupons.md
+++ b/docs/NewCoupons.md
@@ -8,6 +8,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **usageLimit** | **Integer** | The number of times a coupon code can be redeemed. This can be set to 0 for no limit, but any campaign usage limits will still apply.  | 
+**discountLimit** | [**BigDecimal**](BigDecimal.md) | The amount of discounts that can be given with this coupon code.  |  [optional]
 **startDate** | [**OffsetDateTime**](OffsetDateTime.md) | Timestamp at which point the coupon becomes valid. |  [optional]
 **expiryDate** | [**OffsetDateTime**](OffsetDateTime.md) | Expiry date of the coupon. Coupon never expires if this is omitted, zero, or negative. |  [optional]
 **validCharacters** | **List&lt;String&gt;** | Set of characters to be used when generating random part of code. Defaults to [A-Z, 0-9] (in terms of RegExp). | 

--- a/docs/UpdateApplication.md
+++ b/docs/UpdateApplication.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **caseSensitivity** | [**CaseSensitivityEnum**](#CaseSensitivityEnum) | A string indicating how should campaigns in this application deal with case sensitivity on coupon codes. |  [optional]
 **attributes** | [**Object**](.md) | Arbitrary properties associated with this campaign |  [optional]
 **limits** | [**List&lt;LimitConfig&gt;**](LimitConfig.md) | Default limits for campaigns created in this application |  [optional]
+**campaignPriority** | [**CampaignPriorityEnum**](#CampaignPriorityEnum) | Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive) |  [optional]
 **attributesSettings** | [**AttributesSettings**](AttributesSettings.md) |  |  [optional]
 
 
@@ -24,6 +25,16 @@ Name | Value
 SENSITIVE | &quot;sensitive&quot;
 INSENSITIVE_UPPERCASE | &quot;insensitive-uppercase&quot;
 INSENSITIVE_LOWERCASE | &quot;insensitive-lowercase&quot;
+
+
+
+## Enum: CampaignPriorityEnum
+
+Name | Value
+---- | -----
+UNIVERSAL | &quot;universal&quot;
+STACKABLE | &quot;stackable&quot;
+EXCLUSIVE | &quot;exclusive&quot;
 
 
 

--- a/docs/UpdateCoupon.md
+++ b/docs/UpdateCoupon.md
@@ -8,6 +8,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **usageLimit** | **Integer** | The number of times a coupon code can be redeemed. This can be set to 0 for no limit, but any campaign usage limits will still apply.  |  [optional]
+**discountLimit** | [**BigDecimal**](BigDecimal.md) | The amount of discounts that can be given with this coupon code.  |  [optional]
 **startDate** | [**OffsetDateTime**](OffsetDateTime.md) | Timestamp at which point the coupon becomes valid. |  [optional]
 **expiryDate** | [**OffsetDateTime**](OffsetDateTime.md) | Expiry date of the coupon. Coupon never expires if this is omitted, zero, or negative. |  [optional]
 **recipientIntegrationId** | **String** | The integration ID for this coupon&#39;s beneficiary&#39;s profile |  [optional]

--- a/docs/UpdateCouponBatch.md
+++ b/docs/UpdateCouponBatch.md
@@ -8,6 +8,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **usageLimit** | **Integer** | The number of times a coupon code can be redeemed. This can be set to 0 for no limit, but any campaign usage limits will still apply.  |  [optional]
+**discountLimit** | [**BigDecimal**](BigDecimal.md) | The amount of discounts that can be given with this coupon code.  |  [optional]
 **startDate** | [**OffsetDateTime**](OffsetDateTime.md) | Timestamp at which point the coupon becomes valid. |  [optional]
 **expiryDate** | [**OffsetDateTime**](OffsetDateTime.md) | Expiry date of the coupon. Coupon never expires if this is omitted, zero, or negative. |  [optional]
 **attributes** | [**Object**](.md) | Arbitrary properties associated with this item |  [optional]

--- a/git_push.sh
+++ b/git_push.sh
@@ -14,12 +14,12 @@ if [ "$git_host" = "" ]; then
 fi
 
 if [ "$git_user_id" = "" ]; then
-    git_user_id="GIT_USER_ID"
+    git_user_id="talon-one"
     echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
 fi
 
 if [ "$git_repo_id" = "" ]; then
-    git_repo_id="GIT_REPO_ID"
+    git_repo_id="TalonOneJavaSdk"
     echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>talon-one-client</artifactId>
     <packaging>jar</packaging>
     <name>talon-one-client</name>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
     <url>https://github.com/talon-one/maven-artefacts</url>
     <description>Talon.One unified JAVA SDK. It allows for programmatic access to the integration and management API with their respective authentication strategies</description>
     <scm>
@@ -24,7 +24,7 @@
 
     <developers>
         <developer>
-            <name>Jakob Shimony</name>
+            <name>Talon.One Developers</name>
             <email>devs@talon.one</email>
             <organization>Talon.One GmbH</organization>
             <organizationUrl>https://talon.one</organizationUrl>

--- a/src/main/java/one/talon/ApiClient.java
+++ b/src/main/java/one/talon/ApiClient.java
@@ -128,7 +128,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("OpenAPI-Generator/4.0.0/java");
+        setUserAgent("OpenAPI-Generator/4.1.0/java");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/one/talon/api/IntegrationApi.java
+++ b/src/main/java/one/talon/api/IntegrationApi.java
@@ -30,8 +30,8 @@ import java.io.IOException;
 import one.talon.model.Coupon;
 import one.talon.model.CouponReservations;
 import one.talon.model.CustomerInventory;
+import one.talon.model.CustomerProfileUpdate;
 import one.talon.model.InlineResponse200;
-import one.talon.model.InlineResponse2001;
 import one.talon.model.IntegrationRequest;
 import one.talon.model.IntegrationState;
 import one.talon.model.IntegrationStateV2;
@@ -522,8 +522,9 @@ public class IntegrationApi {
     /**
      * Build call for getCustomerInventory
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @param profile optional flag to decide if you would like customer profile information in the response (optional, default to null)
-     * @param referrals optional flag to decide if you would like referral information in the response (optional, default to null)
+     * @param profile optional flag to decide if you would like customer profile information in the response (optional)
+     * @param referrals optional flag to decide if you would like referral information in the response (optional)
+     * @param coupons optional flag to decide if you would like coupon information in the response (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -533,7 +534,7 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getCustomerInventoryCall(String integrationId, Object profile, Object referrals, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getCustomerInventoryCall(String integrationId, Boolean profile, Boolean referrals, Boolean coupons, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -550,6 +551,10 @@ public class IntegrationApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("referrals", referrals));
         }
 
+        if (coupons != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("coupons", coupons));
+        }
+
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
@@ -572,7 +577,7 @@ public class IntegrationApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getCustomerInventoryValidateBeforeCall(String integrationId, Object profile, Object referrals, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getCustomerInventoryValidateBeforeCall(String integrationId, Boolean profile, Boolean referrals, Boolean coupons, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'integrationId' is set
         if (integrationId == null) {
@@ -580,17 +585,18 @@ public class IntegrationApi {
         }
         
 
-        okhttp3.Call localVarCall = getCustomerInventoryCall(integrationId, profile, referrals, _callback);
+        okhttp3.Call localVarCall = getCustomerInventoryCall(integrationId, profile, referrals, coupons, _callback);
         return localVarCall;
 
     }
 
     /**
      * Get an inventory of all data associated with a specific customer profile.
-     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information and referral codes. In the future, this will be expanded with coupon codes and loyalty points.
+     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information, referral codes and reserved coupons. In the future, this will be expanded with loyalty points.
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @param profile optional flag to decide if you would like customer profile information in the response (optional, default to null)
-     * @param referrals optional flag to decide if you would like referral information in the response (optional, default to null)
+     * @param profile optional flag to decide if you would like customer profile information in the response (optional)
+     * @param referrals optional flag to decide if you would like referral information in the response (optional)
+     * @param coupons optional flag to decide if you would like coupon information in the response (optional)
      * @return CustomerInventory
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -599,17 +605,18 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public CustomerInventory getCustomerInventory(String integrationId, Object profile, Object referrals) throws ApiException {
-        ApiResponse<CustomerInventory> localVarResp = getCustomerInventoryWithHttpInfo(integrationId, profile, referrals);
+    public CustomerInventory getCustomerInventory(String integrationId, Boolean profile, Boolean referrals, Boolean coupons) throws ApiException {
+        ApiResponse<CustomerInventory> localVarResp = getCustomerInventoryWithHttpInfo(integrationId, profile, referrals, coupons);
         return localVarResp.getData();
     }
 
     /**
      * Get an inventory of all data associated with a specific customer profile.
-     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information and referral codes. In the future, this will be expanded with coupon codes and loyalty points.
+     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information, referral codes and reserved coupons. In the future, this will be expanded with loyalty points.
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @param profile optional flag to decide if you would like customer profile information in the response (optional, default to null)
-     * @param referrals optional flag to decide if you would like referral information in the response (optional, default to null)
+     * @param profile optional flag to decide if you would like customer profile information in the response (optional)
+     * @param referrals optional flag to decide if you would like referral information in the response (optional)
+     * @param coupons optional flag to decide if you would like coupon information in the response (optional)
      * @return ApiResponse&lt;CustomerInventory&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -618,18 +625,19 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<CustomerInventory> getCustomerInventoryWithHttpInfo(String integrationId, Object profile, Object referrals) throws ApiException {
-        okhttp3.Call localVarCall = getCustomerInventoryValidateBeforeCall(integrationId, profile, referrals, null);
+    public ApiResponse<CustomerInventory> getCustomerInventoryWithHttpInfo(String integrationId, Boolean profile, Boolean referrals, Boolean coupons) throws ApiException {
+        okhttp3.Call localVarCall = getCustomerInventoryValidateBeforeCall(integrationId, profile, referrals, coupons, null);
         Type localVarReturnType = new TypeToken<CustomerInventory>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
      * Get an inventory of all data associated with a specific customer profile. (asynchronously)
-     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information and referral codes. In the future, this will be expanded with coupon codes and loyalty points.
+     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information, referral codes and reserved coupons. In the future, this will be expanded with loyalty points.
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @param profile optional flag to decide if you would like customer profile information in the response (optional, default to null)
-     * @param referrals optional flag to decide if you would like referral information in the response (optional, default to null)
+     * @param profile optional flag to decide if you would like customer profile information in the response (optional)
+     * @param referrals optional flag to decide if you would like referral information in the response (optional)
+     * @param coupons optional flag to decide if you would like coupon information in the response (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -639,121 +647,10 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getCustomerInventoryAsync(String integrationId, Object profile, Object referrals, final ApiCallback<CustomerInventory> _callback) throws ApiException {
+    public okhttp3.Call getCustomerInventoryAsync(String integrationId, Boolean profile, Boolean referrals, Boolean coupons, final ApiCallback<CustomerInventory> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getCustomerInventoryValidateBeforeCall(integrationId, profile, referrals, _callback);
+        okhttp3.Call localVarCall = getCustomerInventoryValidateBeforeCall(integrationId, profile, referrals, coupons, _callback);
         Type localVarReturnType = new TypeToken<CustomerInventory>(){}.getType();
-        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
-        return localVarCall;
-    }
-    /**
-     * Build call for getReservedCoupons
-     * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @param _callback Callback for upload/download progress
-     * @return Call to execute
-     * @throws ApiException If fail to serialize the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call getReservedCouponsCall(String integrationId, final ApiCallback _callback) throws ApiException {
-        Object localVarPostBody = null;
-
-        // create path and map variables
-        String localVarPath = "/v1/coupon_reservations/coupons/{integrationId}"
-            .replaceAll("\\{" + "integrationId" + "\\}", localVarApiClient.escapeString(integrationId.toString()));
-
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-        Map<String, String> localVarCookieParams = new HashMap<String, String>();
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        final String[] localVarAccepts = {
-            "application/json"
-        };
-        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
-        if (localVarAccept != null) {
-            localVarHeaderParams.put("Accept", localVarAccept);
-        }
-
-        final String[] localVarContentTypes = {
-            
-        };
-        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
-        localVarHeaderParams.put("Content-Type", localVarContentType);
-
-        String[] localVarAuthNames = new String[] { "api_key_v1", "integration_auth" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
-    }
-
-    @SuppressWarnings("rawtypes")
-    private okhttp3.Call getReservedCouponsValidateBeforeCall(String integrationId, final ApiCallback _callback) throws ApiException {
-        
-        // verify the required parameter 'integrationId' is set
-        if (integrationId == null) {
-            throw new ApiException("Missing the required parameter 'integrationId' when calling getReservedCoupons(Async)");
-        }
-        
-
-        okhttp3.Call localVarCall = getReservedCouponsCall(integrationId, _callback);
-        return localVarCall;
-
-    }
-
-    /**
-     * Get all valid reserved coupons
-     * Returns all coupons this user is subscribed to that are valid and usable 
-     * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @return InlineResponse2001
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public InlineResponse2001 getReservedCoupons(String integrationId) throws ApiException {
-        ApiResponse<InlineResponse2001> localVarResp = getReservedCouponsWithHttpInfo(integrationId);
-        return localVarResp.getData();
-    }
-
-    /**
-     * Get all valid reserved coupons
-     * Returns all coupons this user is subscribed to that are valid and usable 
-     * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @return ApiResponse&lt;InlineResponse2001&gt;
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public ApiResponse<InlineResponse2001> getReservedCouponsWithHttpInfo(String integrationId) throws ApiException {
-        okhttp3.Call localVarCall = getReservedCouponsValidateBeforeCall(integrationId, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
-        return localVarApiClient.execute(localVarCall, localVarReturnType);
-    }
-
-    /**
-     * Get all valid reserved coupons (asynchronously)
-     * Returns all coupons this user is subscribed to that are valid and usable 
-     * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
-     * @param _callback The callback to be executed when the API call finishes
-     * @return The request call
-     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call getReservedCouponsAsync(String integrationId, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
-
-        okhttp3.Call localVarCall = getReservedCouponsValidateBeforeCall(integrationId, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -871,6 +768,7 @@ public class IntegrationApi {
     /**
      * Build call for trackEvent
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -880,7 +778,7 @@ public class IntegrationApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call trackEventCall(NewEvent body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call trackEventCall(NewEvent body, Boolean dry, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -888,6 +786,10 @@ public class IntegrationApi {
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (dry != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("dry", dry));
+        }
+
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
@@ -910,7 +812,7 @@ public class IntegrationApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call trackEventValidateBeforeCall(NewEvent body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call trackEventValidateBeforeCall(NewEvent body, Boolean dry, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -918,7 +820,7 @@ public class IntegrationApi {
         }
         
 
-        okhttp3.Call localVarCall = trackEventCall(body, _callback);
+        okhttp3.Call localVarCall = trackEventCall(body, dry, _callback);
         return localVarCall;
 
     }
@@ -927,6 +829,7 @@ public class IntegrationApi {
      * Track an Event
      * Records an arbitrary event in a customer session. For example, an integration might record an event when a user updates their payment information.  The &#x60;sessionId&#x60; body parameter is required, an event is always part of a session. Much like updating a customer session, if either the profile or the session do not exist, a new empty one will be created. Note that if the specified session already exists, it must belong to the same &#x60;profileId&#x60; or an error will be returned.  As with customer sessions, you can use an empty string for &#x60;profileId&#x60; to indicate that this is an anonymous session.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place. 
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @return IntegrationState
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -935,8 +838,8 @@ public class IntegrationApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
      </table>
      */
-    public IntegrationState trackEvent(NewEvent body) throws ApiException {
-        ApiResponse<IntegrationState> localVarResp = trackEventWithHttpInfo(body);
+    public IntegrationState trackEvent(NewEvent body, Boolean dry) throws ApiException {
+        ApiResponse<IntegrationState> localVarResp = trackEventWithHttpInfo(body, dry);
         return localVarResp.getData();
     }
 
@@ -944,6 +847,7 @@ public class IntegrationApi {
      * Track an Event
      * Records an arbitrary event in a customer session. For example, an integration might record an event when a user updates their payment information.  The &#x60;sessionId&#x60; body parameter is required, an event is always part of a session. Much like updating a customer session, if either the profile or the session do not exist, a new empty one will be created. Note that if the specified session already exists, it must belong to the same &#x60;profileId&#x60; or an error will be returned.  As with customer sessions, you can use an empty string for &#x60;profileId&#x60; to indicate that this is an anonymous session.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place. 
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @return ApiResponse&lt;IntegrationState&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -952,8 +856,8 @@ public class IntegrationApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<IntegrationState> trackEventWithHttpInfo(NewEvent body) throws ApiException {
-        okhttp3.Call localVarCall = trackEventValidateBeforeCall(body, null);
+    public ApiResponse<IntegrationState> trackEventWithHttpInfo(NewEvent body, Boolean dry) throws ApiException {
+        okhttp3.Call localVarCall = trackEventValidateBeforeCall(body, dry, null);
         Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -962,6 +866,7 @@ public class IntegrationApi {
      * Track an Event (asynchronously)
      * Records an arbitrary event in a customer session. For example, an integration might record an event when a user updates their payment information.  The &#x60;sessionId&#x60; body parameter is required, an event is always part of a session. Much like updating a customer session, if either the profile or the session do not exist, a new empty one will be created. Note that if the specified session already exists, it must belong to the same &#x60;profileId&#x60; or an error will be returned.  As with customer sessions, you can use an empty string for &#x60;profileId&#x60; to indicate that this is an anonymous session.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place. 
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -971,9 +876,9 @@ public class IntegrationApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call trackEventAsync(NewEvent body, final ApiCallback<IntegrationState> _callback) throws ApiException {
+    public okhttp3.Call trackEventAsync(NewEvent body, Boolean dry, final ApiCallback<IntegrationState> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = trackEventValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = trackEventValidateBeforeCall(body, dry, _callback);
         Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
@@ -982,6 +887,7 @@ public class IntegrationApi {
      * Build call for updateCustomerProfile
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -991,7 +897,7 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateCustomerProfileCall(String integrationId, NewCustomerProfile body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updateCustomerProfileCall(String integrationId, NewCustomerProfile body, Boolean dry, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -1000,6 +906,10 @@ public class IntegrationApi {
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (dry != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("dry", dry));
+        }
+
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
@@ -1022,7 +932,7 @@ public class IntegrationApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updateCustomerProfileValidateBeforeCall(String integrationId, NewCustomerProfile body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updateCustomerProfileValidateBeforeCall(String integrationId, NewCustomerProfile body, Boolean dry, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'integrationId' is set
         if (integrationId == null) {
@@ -1035,7 +945,7 @@ public class IntegrationApi {
         }
         
 
-        okhttp3.Call localVarCall = updateCustomerProfileCall(integrationId, body, _callback);
+        okhttp3.Call localVarCall = updateCustomerProfileCall(integrationId, body, dry, _callback);
         return localVarCall;
 
     }
@@ -1045,6 +955,7 @@ public class IntegrationApi {
      * Update (or create) a [Customer Profile][]. This profile information can then be matched and/or updated by campaign [Rules][].  The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  [Customer Profile]: /Getting-Started/entities#customer-profile [Rules]: /Getting-Started/entities#campaigns-rulesets-and-coupons 
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @return IntegrationState
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1053,8 +964,8 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public IntegrationState updateCustomerProfile(String integrationId, NewCustomerProfile body) throws ApiException {
-        ApiResponse<IntegrationState> localVarResp = updateCustomerProfileWithHttpInfo(integrationId, body);
+    public IntegrationState updateCustomerProfile(String integrationId, NewCustomerProfile body, Boolean dry) throws ApiException {
+        ApiResponse<IntegrationState> localVarResp = updateCustomerProfileWithHttpInfo(integrationId, body, dry);
         return localVarResp.getData();
     }
 
@@ -1063,6 +974,7 @@ public class IntegrationApi {
      * Update (or create) a [Customer Profile][]. This profile information can then be matched and/or updated by campaign [Rules][].  The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  [Customer Profile]: /Getting-Started/entities#customer-profile [Rules]: /Getting-Started/entities#campaigns-rulesets-and-coupons 
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @return ApiResponse&lt;IntegrationState&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1071,8 +983,8 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<IntegrationState> updateCustomerProfileWithHttpInfo(String integrationId, NewCustomerProfile body) throws ApiException {
-        okhttp3.Call localVarCall = updateCustomerProfileValidateBeforeCall(integrationId, body, null);
+    public ApiResponse<IntegrationState> updateCustomerProfileWithHttpInfo(String integrationId, NewCustomerProfile body, Boolean dry) throws ApiException {
+        okhttp3.Call localVarCall = updateCustomerProfileValidateBeforeCall(integrationId, body, dry, null);
         Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -1082,6 +994,7 @@ public class IntegrationApi {
      * Update (or create) a [Customer Profile][]. This profile information can then be matched and/or updated by campaign [Rules][].  The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  [Customer Profile]: /Getting-Started/entities#customer-profile [Rules]: /Getting-Started/entities#campaigns-rulesets-and-coupons 
      * @param integrationId The custom identifier for this profile, must be unique within the account. (required)
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -1091,16 +1004,16 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateCustomerProfileAsync(String integrationId, NewCustomerProfile body, final ApiCallback<IntegrationState> _callback) throws ApiException {
+    public okhttp3.Call updateCustomerProfileAsync(String integrationId, NewCustomerProfile body, Boolean dry, final ApiCallback<IntegrationState> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updateCustomerProfileValidateBeforeCall(integrationId, body, _callback);
+        okhttp3.Call localVarCall = updateCustomerProfileValidateBeforeCall(integrationId, body, dry, _callback);
         Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
     /**
-     * Build call for updateCustomerSession
-     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
+     * Build call for updateCustomerProfileV2
+     * @param customerProfileId The custom identifier for this profile, must be unique within the account. (required)
      * @param body  (required)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
@@ -1111,132 +1024,12 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateCustomerSessionCall(String customerSessionId, NewCustomerSession body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updateCustomerProfileV2Call(String customerProfileId, NewCustomerProfile body, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
-        String localVarPath = "/v1/customer_sessions/{customerSessionId}"
-            .replaceAll("\\{" + "customerSessionId" + "\\}", localVarApiClient.escapeString(customerSessionId.toString()));
-
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-        Map<String, String> localVarCookieParams = new HashMap<String, String>();
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        final String[] localVarAccepts = {
-            "application/json"
-        };
-        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
-        if (localVarAccept != null) {
-            localVarHeaderParams.put("Accept", localVarAccept);
-        }
-
-        final String[] localVarContentTypes = {
-            "application/json"
-        };
-        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
-        localVarHeaderParams.put("Content-Type", localVarContentType);
-
-        String[] localVarAuthNames = new String[] { "api_key_v1", "integration_auth" };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
-    }
-
-    @SuppressWarnings("rawtypes")
-    private okhttp3.Call updateCustomerSessionValidateBeforeCall(String customerSessionId, NewCustomerSession body, final ApiCallback _callback) throws ApiException {
-        
-        // verify the required parameter 'customerSessionId' is set
-        if (customerSessionId == null) {
-            throw new ApiException("Missing the required parameter 'customerSessionId' when calling updateCustomerSession(Async)");
-        }
-        
-        // verify the required parameter 'body' is set
-        if (body == null) {
-            throw new ApiException("Missing the required parameter 'body' when calling updateCustomerSession(Async)");
-        }
-        
-
-        okhttp3.Call localVarCall = updateCustomerSessionCall(customerSessionId, body, _callback);
-        return localVarCall;
-
-    }
-
-    /**
-     * Update a Customer Session
-     * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
-     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
-     * @param body  (required)
-     * @return IntegrationState
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public IntegrationState updateCustomerSession(String customerSessionId, NewCustomerSession body) throws ApiException {
-        ApiResponse<IntegrationState> localVarResp = updateCustomerSessionWithHttpInfo(customerSessionId, body);
-        return localVarResp.getData();
-    }
-
-    /**
-     * Update a Customer Session
-     * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
-     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
-     * @param body  (required)
-     * @return ApiResponse&lt;IntegrationState&gt;
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public ApiResponse<IntegrationState> updateCustomerSessionWithHttpInfo(String customerSessionId, NewCustomerSession body) throws ApiException {
-        okhttp3.Call localVarCall = updateCustomerSessionValidateBeforeCall(customerSessionId, body, null);
-        Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
-        return localVarApiClient.execute(localVarCall, localVarReturnType);
-    }
-
-    /**
-     * Update a Customer Session (asynchronously)
-     * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
-     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
-     * @param body  (required)
-     * @param _callback The callback to be executed when the API call finishes
-     * @return The request call
-     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call updateCustomerSessionAsync(String customerSessionId, NewCustomerSession body, final ApiCallback<IntegrationState> _callback) throws ApiException {
-
-        okhttp3.Call localVarCall = updateCustomerSessionValidateBeforeCall(customerSessionId, body, _callback);
-        Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
-        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
-        return localVarCall;
-    }
-    /**
-     * Build call for updateCustomerSessionV2
-     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
-     * @param body  (required)
-     * @param _callback Callback for upload/download progress
-     * @return Call to execute
-     * @throws ApiException If fail to serialize the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call updateCustomerSessionV2Call(String customerSessionId, IntegrationRequest body, final ApiCallback _callback) throws ApiException {
-        Object localVarPostBody = body;
-
-        // create path and map variables
-        String localVarPath = "/v2/customer_sessions/{customerSessionId}"
-            .replaceAll("\\{" + "customerSessionId" + "\\}", localVarApiClient.escapeString(customerSessionId.toString()));
+        String localVarPath = "/v2/customer_profiles/{customerProfileId}"
+            .replaceAll("\\{" + "customerProfileId" + "\\}", localVarApiClient.escapeString(customerProfileId.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -1262,7 +1055,260 @@ public class IntegrationApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updateCustomerSessionV2ValidateBeforeCall(String customerSessionId, IntegrationRequest body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updateCustomerProfileV2ValidateBeforeCall(String customerProfileId, NewCustomerProfile body, final ApiCallback _callback) throws ApiException {
+        
+        // verify the required parameter 'customerProfileId' is set
+        if (customerProfileId == null) {
+            throw new ApiException("Missing the required parameter 'customerProfileId' when calling updateCustomerProfileV2(Async)");
+        }
+        
+        // verify the required parameter 'body' is set
+        if (body == null) {
+            throw new ApiException("Missing the required parameter 'body' when calling updateCustomerProfileV2(Async)");
+        }
+        
+
+        okhttp3.Call localVarCall = updateCustomerProfileV2Call(customerProfileId, body, _callback);
+        return localVarCall;
+
+    }
+
+    /**
+     * Update a Customer Profile
+     * Update (or create) a [Customer Profile][].   The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  [Customer Profile]: /Getting-Started/entities#customer-profile 
+     * @param customerProfileId The custom identifier for this profile, must be unique within the account. (required)
+     * @param body  (required)
+     * @return CustomerProfileUpdate
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public CustomerProfileUpdate updateCustomerProfileV2(String customerProfileId, NewCustomerProfile body) throws ApiException {
+        ApiResponse<CustomerProfileUpdate> localVarResp = updateCustomerProfileV2WithHttpInfo(customerProfileId, body);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Update a Customer Profile
+     * Update (or create) a [Customer Profile][].   The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  [Customer Profile]: /Getting-Started/entities#customer-profile 
+     * @param customerProfileId The custom identifier for this profile, must be unique within the account. (required)
+     * @param body  (required)
+     * @return ApiResponse&lt;CustomerProfileUpdate&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<CustomerProfileUpdate> updateCustomerProfileV2WithHttpInfo(String customerProfileId, NewCustomerProfile body) throws ApiException {
+        okhttp3.Call localVarCall = updateCustomerProfileV2ValidateBeforeCall(customerProfileId, body, null);
+        Type localVarReturnType = new TypeToken<CustomerProfileUpdate>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Update a Customer Profile (asynchronously)
+     * Update (or create) a [Customer Profile][].   The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  [Customer Profile]: /Getting-Started/entities#customer-profile 
+     * @param customerProfileId The custom identifier for this profile, must be unique within the account. (required)
+     * @param body  (required)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call updateCustomerProfileV2Async(String customerProfileId, NewCustomerProfile body, final ApiCallback<CustomerProfileUpdate> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = updateCustomerProfileV2ValidateBeforeCall(customerProfileId, body, _callback);
+        Type localVarReturnType = new TypeToken<CustomerProfileUpdate>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+    /**
+     * Build call for updateCustomerSession
+     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
+     * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call updateCustomerSessionCall(String customerSessionId, NewCustomerSession body, Boolean dry, final ApiCallback _callback) throws ApiException {
+        Object localVarPostBody = body;
+
+        // create path and map variables
+        String localVarPath = "/v1/customer_sessions/{customerSessionId}"
+            .replaceAll("\\{" + "customerSessionId" + "\\}", localVarApiClient.escapeString(customerSessionId.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (dry != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("dry", dry));
+        }
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        String[] localVarAuthNames = new String[] { "api_key_v1", "integration_auth" };
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call updateCustomerSessionValidateBeforeCall(String customerSessionId, NewCustomerSession body, Boolean dry, final ApiCallback _callback) throws ApiException {
+        
+        // verify the required parameter 'customerSessionId' is set
+        if (customerSessionId == null) {
+            throw new ApiException("Missing the required parameter 'customerSessionId' when calling updateCustomerSession(Async)");
+        }
+        
+        // verify the required parameter 'body' is set
+        if (body == null) {
+            throw new ApiException("Missing the required parameter 'body' when calling updateCustomerSession(Async)");
+        }
+        
+
+        okhttp3.Call localVarCall = updateCustomerSessionCall(customerSessionId, body, dry, _callback);
+        return localVarCall;
+
+    }
+
+    /**
+     * Update a Customer Session
+     * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
+     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
+     * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
+     * @return IntegrationState
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public IntegrationState updateCustomerSession(String customerSessionId, NewCustomerSession body, Boolean dry) throws ApiException {
+        ApiResponse<IntegrationState> localVarResp = updateCustomerSessionWithHttpInfo(customerSessionId, body, dry);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Update a Customer Session
+     * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
+     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
+     * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
+     * @return ApiResponse&lt;IntegrationState&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<IntegrationState> updateCustomerSessionWithHttpInfo(String customerSessionId, NewCustomerSession body, Boolean dry) throws ApiException {
+        okhttp3.Call localVarCall = updateCustomerSessionValidateBeforeCall(customerSessionId, body, dry, null);
+        Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Update a Customer Session (asynchronously)
+     * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the full integration state. This includes the current state of the customer profile, the customer session, the event that was recorded, and an array of effects that took place.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
+     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
+     * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call updateCustomerSessionAsync(String customerSessionId, NewCustomerSession body, Boolean dry, final ApiCallback<IntegrationState> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = updateCustomerSessionValidateBeforeCall(customerSessionId, body, dry, _callback);
+        Type localVarReturnType = new TypeToken<IntegrationState>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+    /**
+     * Build call for updateCustomerSessionV2
+     * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
+     * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call updateCustomerSessionV2Call(String customerSessionId, IntegrationRequest body, Boolean dry, final ApiCallback _callback) throws ApiException {
+        Object localVarPostBody = body;
+
+        // create path and map variables
+        String localVarPath = "/v2/customer_sessions/{customerSessionId}"
+            .replaceAll("\\{" + "customerSessionId" + "\\}", localVarApiClient.escapeString(customerSessionId.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (dry != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("dry", dry));
+        }
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        String[] localVarAuthNames = new String[] { "api_key_v1" };
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call updateCustomerSessionV2ValidateBeforeCall(String customerSessionId, IntegrationRequest body, Boolean dry, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'customerSessionId' is set
         if (customerSessionId == null) {
@@ -1275,7 +1321,7 @@ public class IntegrationApi {
         }
         
 
-        okhttp3.Call localVarCall = updateCustomerSessionV2Call(customerSessionId, body, _callback);
+        okhttp3.Call localVarCall = updateCustomerSessionV2Call(customerSessionId, body, dry, _callback);
         return localVarCall;
 
     }
@@ -1285,6 +1331,7 @@ public class IntegrationApi {
      * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the requested integration state. This includes the effects that were generated due to triggered campaigns, the created coupons and referral objects, as well as any entity that was requested in the request parameter \&quot;responseContent\&quot;.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
      * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @return IntegrationStateV2
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1293,8 +1340,8 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public IntegrationStateV2 updateCustomerSessionV2(String customerSessionId, IntegrationRequest body) throws ApiException {
-        ApiResponse<IntegrationStateV2> localVarResp = updateCustomerSessionV2WithHttpInfo(customerSessionId, body);
+    public IntegrationStateV2 updateCustomerSessionV2(String customerSessionId, IntegrationRequest body, Boolean dry) throws ApiException {
+        ApiResponse<IntegrationStateV2> localVarResp = updateCustomerSessionV2WithHttpInfo(customerSessionId, body, dry);
         return localVarResp.getData();
     }
 
@@ -1303,6 +1350,7 @@ public class IntegrationApi {
      * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the requested integration state. This includes the effects that were generated due to triggered campaigns, the created coupons and referral objects, as well as any entity that was requested in the request parameter \&quot;responseContent\&quot;.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
      * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @return ApiResponse&lt;IntegrationStateV2&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1311,8 +1359,8 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<IntegrationStateV2> updateCustomerSessionV2WithHttpInfo(String customerSessionId, IntegrationRequest body) throws ApiException {
-        okhttp3.Call localVarCall = updateCustomerSessionV2ValidateBeforeCall(customerSessionId, body, null);
+    public ApiResponse<IntegrationStateV2> updateCustomerSessionV2WithHttpInfo(String customerSessionId, IntegrationRequest body, Boolean dry) throws ApiException {
+        okhttp3.Call localVarCall = updateCustomerSessionV2ValidateBeforeCall(customerSessionId, body, dry, null);
         Type localVarReturnType = new TypeToken<IntegrationStateV2>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -1322,6 +1370,7 @@ public class IntegrationApi {
      * Update (or create) a [Customer Session][]. For example, the items in a customers cart are part of a session.  The Talon.One platform supports multiple simultaneous sessions for the same profile, so if you have multiple ways of accessing the same application you have the option of either tracking multiple independent sessions or using the same session across all of them. You should share sessions when application access points share other state, such as the users cart. If two points of access to the application have independent state (e.g. a user can have different items in their cart across the two) they should use independent customer session ID&#39;s.  The &#x60;profileId&#x60; parameter in the request body should correspond to an &#x60;integrationId&#x60; for a customer profile, to track an anonymous session use the empty string (&#x60;\&quot;\&quot;&#x60;) as the &#x60;profileId&#x60;. Note that you do **not** need to create a customer profile first: if the specified profile does not yet exist, an empty profile will be created automatically.  Updating a customer profile will return a response with the requested integration state. This includes the effects that were generated due to triggered campaigns, the created coupons and referral objects, as well as any entity that was requested in the request parameter \&quot;responseContent\&quot;.  The currency for the session and the cart items in the session is the same as that of the application with which the session is associated.  [Customer Session]: /Getting-Started/entities#customer-session 
      * @param customerSessionId The custom identifier for this session, must be unique within the account. (required)
      * @param body  (required)
+     * @param dry Flag to indicate whether to skip persisting the changes or not (Will not persist if set to &#39;true&#39;). (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -1331,9 +1380,9 @@ public class IntegrationApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateCustomerSessionV2Async(String customerSessionId, IntegrationRequest body, final ApiCallback<IntegrationStateV2> _callback) throws ApiException {
+    public okhttp3.Call updateCustomerSessionV2Async(String customerSessionId, IntegrationRequest body, Boolean dry, final ApiCallback<IntegrationStateV2> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updateCustomerSessionV2ValidateBeforeCall(customerSessionId, body, _callback);
+        okhttp3.Call localVarCall = updateCustomerSessionV2ValidateBeforeCall(customerSessionId, body, dry, _callback);
         Type localVarReturnType = new TypeToken<IntegrationStateV2>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/src/main/java/one/talon/api/ManagementApi.java
+++ b/src/main/java/one/talon/api/ManagementApi.java
@@ -40,7 +40,6 @@ import java.math.BigDecimal;
 import one.talon.model.Campaign;
 import one.talon.model.CampaignCopy;
 import one.talon.model.CampaignSearch;
-import one.talon.model.CampaignSet;
 import one.talon.model.Coupon;
 import one.talon.model.CouponSearch;
 import one.talon.model.CustomerActivityReport;
@@ -82,7 +81,6 @@ import one.talon.model.LoyaltyProgram;
 import one.talon.model.NewAdditionalCost;
 import one.talon.model.NewAttribute;
 import one.talon.model.NewCampaign;
-import one.talon.model.NewCampaignSet;
 import one.talon.model.NewCoupons;
 import one.talon.model.NewPassword;
 import one.talon.model.NewPasswordEmail;
@@ -323,7 +321,7 @@ public class ManagementApi {
      * @param applicationId  (required)
      * @param campaignId  (required)
      * @param body  (required)
-     * @return InlineResponse2003
+     * @return InlineResponse2002
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -331,8 +329,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2003 copyCampaignToApplications(Integer applicationId, Integer campaignId, CampaignCopy body) throws ApiException {
-        ApiResponse<InlineResponse2003> localVarResp = copyCampaignToApplicationsWithHttpInfo(applicationId, campaignId, body);
+    public InlineResponse2002 copyCampaignToApplications(Integer applicationId, Integer campaignId, CampaignCopy body) throws ApiException {
+        ApiResponse<InlineResponse2002> localVarResp = copyCampaignToApplicationsWithHttpInfo(applicationId, campaignId, body);
         return localVarResp.getData();
     }
 
@@ -342,7 +340,7 @@ public class ManagementApi {
      * @param applicationId  (required)
      * @param campaignId  (required)
      * @param body  (required)
-     * @return ApiResponse&lt;InlineResponse2003&gt;
+     * @return ApiResponse&lt;InlineResponse2002&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -350,9 +348,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2003> copyCampaignToApplicationsWithHttpInfo(Integer applicationId, Integer campaignId, CampaignCopy body) throws ApiException {
+    public ApiResponse<InlineResponse2002> copyCampaignToApplicationsWithHttpInfo(Integer applicationId, Integer campaignId, CampaignCopy body) throws ApiException {
         okhttp3.Call localVarCall = copyCampaignToApplicationsValidateBeforeCall(applicationId, campaignId, body, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -371,10 +369,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call copyCampaignToApplicationsAsync(Integer applicationId, Integer campaignId, CampaignCopy body, final ApiCallback<InlineResponse2003> _callback) throws ApiException {
+    public okhttp3.Call copyCampaignToApplicationsAsync(Integer applicationId, Integer campaignId, CampaignCopy body, final ApiCallback<InlineResponse2002> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = copyCampaignToApplicationsValidateBeforeCall(applicationId, campaignId, body, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -800,7 +798,7 @@ public class ManagementApi {
      * @param campaignId  (required)
      * @param body  (required)
      * @param silent If set to &#39;yes&#39;, response will be an empty 204, otherwise a list of the coupons generated (to to 1000). (optional)
-     * @return InlineResponse2001
+     * @return InlineResponse2004
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -809,8 +807,8 @@ public class ManagementApi {
         <tr><td> 204 </td><td> No Content </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2001 createCoupons(Integer applicationId, Integer campaignId, NewCoupons body, String silent) throws ApiException {
-        ApiResponse<InlineResponse2001> localVarResp = createCouponsWithHttpInfo(applicationId, campaignId, body, silent);
+    public InlineResponse2004 createCoupons(Integer applicationId, Integer campaignId, NewCoupons body, String silent) throws ApiException {
+        ApiResponse<InlineResponse2004> localVarResp = createCouponsWithHttpInfo(applicationId, campaignId, body, silent);
         return localVarResp.getData();
     }
 
@@ -821,7 +819,7 @@ public class ManagementApi {
      * @param campaignId  (required)
      * @param body  (required)
      * @param silent If set to &#39;yes&#39;, response will be an empty 204, otherwise a list of the coupons generated (to to 1000). (optional)
-     * @return ApiResponse&lt;InlineResponse2001&gt;
+     * @return ApiResponse&lt;InlineResponse2004&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -830,9 +828,9 @@ public class ManagementApi {
         <tr><td> 204 </td><td> No Content </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2001> createCouponsWithHttpInfo(Integer applicationId, Integer campaignId, NewCoupons body, String silent) throws ApiException {
+    public ApiResponse<InlineResponse2004> createCouponsWithHttpInfo(Integer applicationId, Integer campaignId, NewCoupons body, String silent) throws ApiException {
         okhttp3.Call localVarCall = createCouponsValidateBeforeCall(applicationId, campaignId, body, silent, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -853,10 +851,10 @@ public class ManagementApi {
         <tr><td> 204 </td><td> No Content </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createCouponsAsync(Integer applicationId, Integer campaignId, NewCoupons body, String silent, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
+    public okhttp3.Call createCouponsAsync(Integer applicationId, Integer campaignId, NewCoupons body, String silent, final ApiCallback<InlineResponse2004> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = createCouponsValidateBeforeCall(applicationId, campaignId, body, silent, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -4561,7 +4559,7 @@ public class ManagementApi {
      * @param pageSize The number of items to include in this response. When omitted, the maximum value of 1000 will be used. (optional)
      * @param skip Skips the given number of items when paging through large result sets. (optional)
      * @param sort The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with &#x60;-&#x60; to sort in descending order. (optional)
-     * @return InlineResponse2002
+     * @return InlineResponse2001
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -4569,8 +4567,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2002 getApplications(Integer pageSize, Integer skip, String sort) throws ApiException {
-        ApiResponse<InlineResponse2002> localVarResp = getApplicationsWithHttpInfo(pageSize, skip, sort);
+    public InlineResponse2001 getApplications(Integer pageSize, Integer skip, String sort) throws ApiException {
+        ApiResponse<InlineResponse2001> localVarResp = getApplicationsWithHttpInfo(pageSize, skip, sort);
         return localVarResp.getData();
     }
 
@@ -4580,7 +4578,7 @@ public class ManagementApi {
      * @param pageSize The number of items to include in this response. When omitted, the maximum value of 1000 will be used. (optional)
      * @param skip Skips the given number of items when paging through large result sets. (optional)
      * @param sort The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with &#x60;-&#x60; to sort in descending order. (optional)
-     * @return ApiResponse&lt;InlineResponse2002&gt;
+     * @return ApiResponse&lt;InlineResponse2001&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -4588,9 +4586,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2002> getApplicationsWithHttpInfo(Integer pageSize, Integer skip, String sort) throws ApiException {
+    public ApiResponse<InlineResponse2001> getApplicationsWithHttpInfo(Integer pageSize, Integer skip, String sort) throws ApiException {
         okhttp3.Call localVarCall = getApplicationsValidateBeforeCall(pageSize, skip, sort, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -4609,10 +4607,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getApplicationsAsync(Integer pageSize, Integer skip, String sort, final ApiCallback<InlineResponse2002> _callback) throws ApiException {
+    public okhttp3.Call getApplicationsAsync(Integer pageSize, Integer skip, String sort, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getApplicationsValidateBeforeCall(pageSize, skip, sort, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -5219,7 +5217,7 @@ public class ManagementApi {
      * @param skip Skips the given number of items when paging through large result sets. (optional)
      * @param sort The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with &#x60;-&#x60; to sort in descending order. (optional)
      * @param campaignState Filter results by the state of the campaign. (optional)
-     * @return InlineResponse2003
+     * @return InlineResponse2002
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -5227,8 +5225,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2003 getCampaignByAttributes(Integer applicationId, CampaignSearch body, Integer pageSize, Integer skip, String sort, String campaignState) throws ApiException {
-        ApiResponse<InlineResponse2003> localVarResp = getCampaignByAttributesWithHttpInfo(applicationId, body, pageSize, skip, sort, campaignState);
+    public InlineResponse2002 getCampaignByAttributes(Integer applicationId, CampaignSearch body, Integer pageSize, Integer skip, String sort, String campaignState) throws ApiException {
+        ApiResponse<InlineResponse2002> localVarResp = getCampaignByAttributesWithHttpInfo(applicationId, body, pageSize, skip, sort, campaignState);
         return localVarResp.getData();
     }
 
@@ -5241,7 +5239,7 @@ public class ManagementApi {
      * @param skip Skips the given number of items when paging through large result sets. (optional)
      * @param sort The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with &#x60;-&#x60; to sort in descending order. (optional)
      * @param campaignState Filter results by the state of the campaign. (optional)
-     * @return ApiResponse&lt;InlineResponse2003&gt;
+     * @return ApiResponse&lt;InlineResponse2002&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -5249,9 +5247,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2003> getCampaignByAttributesWithHttpInfo(Integer applicationId, CampaignSearch body, Integer pageSize, Integer skip, String sort, String campaignState) throws ApiException {
+    public ApiResponse<InlineResponse2002> getCampaignByAttributesWithHttpInfo(Integer applicationId, CampaignSearch body, Integer pageSize, Integer skip, String sort, String campaignState) throws ApiException {
         okhttp3.Call localVarCall = getCampaignByAttributesValidateBeforeCall(applicationId, body, pageSize, skip, sort, campaignState, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -5273,121 +5271,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getCampaignByAttributesAsync(Integer applicationId, CampaignSearch body, Integer pageSize, Integer skip, String sort, String campaignState, final ApiCallback<InlineResponse2003> _callback) throws ApiException {
+    public okhttp3.Call getCampaignByAttributesAsync(Integer applicationId, CampaignSearch body, Integer pageSize, Integer skip, String sort, String campaignState, final ApiCallback<InlineResponse2002> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getCampaignByAttributesValidateBeforeCall(applicationId, body, pageSize, skip, sort, campaignState, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
-        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
-        return localVarCall;
-    }
-    /**
-     * Build call for getCampaignSet
-     * @param applicationId  (required)
-     * @param _callback Callback for upload/download progress
-     * @return Call to execute
-     * @throws ApiException If fail to serialize the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call getCampaignSetCall(Integer applicationId, final ApiCallback _callback) throws ApiException {
-        Object localVarPostBody = null;
-
-        // create path and map variables
-        String localVarPath = "/v1/applications/{applicationId}/campaign_set"
-            .replaceAll("\\{" + "applicationId" + "\\}", localVarApiClient.escapeString(applicationId.toString()));
-
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-        Map<String, String> localVarCookieParams = new HashMap<String, String>();
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        final String[] localVarAccepts = {
-            "application/json"
-        };
-        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
-        if (localVarAccept != null) {
-            localVarHeaderParams.put("Accept", localVarAccept);
-        }
-
-        final String[] localVarContentTypes = {
-            
-        };
-        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
-        localVarHeaderParams.put("Content-Type", localVarContentType);
-
-        String[] localVarAuthNames = new String[] { "manager_auth" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
-    }
-
-    @SuppressWarnings("rawtypes")
-    private okhttp3.Call getCampaignSetValidateBeforeCall(Integer applicationId, final ApiCallback _callback) throws ApiException {
-        
-        // verify the required parameter 'applicationId' is set
-        if (applicationId == null) {
-            throw new ApiException("Missing the required parameter 'applicationId' when calling getCampaignSet(Async)");
-        }
-        
-
-        okhttp3.Call localVarCall = getCampaignSetCall(applicationId, _callback);
-        return localVarCall;
-
-    }
-
-    /**
-     * List CampaignSet
-     * 
-     * @param applicationId  (required)
-     * @return CampaignSet
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public CampaignSet getCampaignSet(Integer applicationId) throws ApiException {
-        ApiResponse<CampaignSet> localVarResp = getCampaignSetWithHttpInfo(applicationId);
-        return localVarResp.getData();
-    }
-
-    /**
-     * List CampaignSet
-     * 
-     * @param applicationId  (required)
-     * @return ApiResponse&lt;CampaignSet&gt;
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public ApiResponse<CampaignSet> getCampaignSetWithHttpInfo(Integer applicationId) throws ApiException {
-        okhttp3.Call localVarCall = getCampaignSetValidateBeforeCall(applicationId, null);
-        Type localVarReturnType = new TypeToken<CampaignSet>(){}.getType();
-        return localVarApiClient.execute(localVarCall, localVarReturnType);
-    }
-
-    /**
-     * List CampaignSet (asynchronously)
-     * 
-     * @param applicationId  (required)
-     * @param _callback The callback to be executed when the API call finishes
-     * @return The request call
-     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call getCampaignSetAsync(Integer applicationId, final ApiCallback<CampaignSet> _callback) throws ApiException {
-
-        okhttp3.Call localVarCall = getCampaignSetValidateBeforeCall(applicationId, _callback);
-        Type localVarReturnType = new TypeToken<CampaignSet>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -5499,7 +5386,7 @@ public class ManagementApi {
      * @param tags Filter results performing case-insensitive matching against the tags of the campaign. When used in conjunction with the \&quot;name\&quot; query parameter, a logical OR will be performed to search both tags and name for the provided values  (optional)
      * @param createdBefore Filter results comparing the parameter value, expected to be an RFC3339 timestamp string, to the campaign creation timestamp. (optional)
      * @param createdAfter Filter results comparing the parameter value, expected to be an RFC3339 timestamp string, to the campaign creation timestamp. (optional)
-     * @return InlineResponse2003
+     * @return InlineResponse2002
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -5507,8 +5394,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2003 getCampaigns(Integer applicationId, Integer pageSize, Integer skip, String sort, String campaignState, String name, String tags, OffsetDateTime createdBefore, OffsetDateTime createdAfter) throws ApiException {
-        ApiResponse<InlineResponse2003> localVarResp = getCampaignsWithHttpInfo(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter);
+    public InlineResponse2002 getCampaigns(Integer applicationId, Integer pageSize, Integer skip, String sort, String campaignState, String name, String tags, OffsetDateTime createdBefore, OffsetDateTime createdAfter) throws ApiException {
+        ApiResponse<InlineResponse2002> localVarResp = getCampaignsWithHttpInfo(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter);
         return localVarResp.getData();
     }
 
@@ -5524,7 +5411,7 @@ public class ManagementApi {
      * @param tags Filter results performing case-insensitive matching against the tags of the campaign. When used in conjunction with the \&quot;name\&quot; query parameter, a logical OR will be performed to search both tags and name for the provided values  (optional)
      * @param createdBefore Filter results comparing the parameter value, expected to be an RFC3339 timestamp string, to the campaign creation timestamp. (optional)
      * @param createdAfter Filter results comparing the parameter value, expected to be an RFC3339 timestamp string, to the campaign creation timestamp. (optional)
-     * @return ApiResponse&lt;InlineResponse2003&gt;
+     * @return ApiResponse&lt;InlineResponse2002&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -5532,9 +5419,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2003> getCampaignsWithHttpInfo(Integer applicationId, Integer pageSize, Integer skip, String sort, String campaignState, String name, String tags, OffsetDateTime createdBefore, OffsetDateTime createdAfter) throws ApiException {
+    public ApiResponse<InlineResponse2002> getCampaignsWithHttpInfo(Integer applicationId, Integer pageSize, Integer skip, String sort, String campaignState, String name, String tags, OffsetDateTime createdBefore, OffsetDateTime createdAfter) throws ApiException {
         okhttp3.Call localVarCall = getCampaignsValidateBeforeCall(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -5559,10 +5446,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getCampaignsAsync(Integer applicationId, Integer pageSize, Integer skip, String sort, String campaignState, String name, String tags, OffsetDateTime createdBefore, OffsetDateTime createdAfter, final ApiCallback<InlineResponse2003> _callback) throws ApiException {
+    public okhttp3.Call getCampaignsAsync(Integer applicationId, Integer pageSize, Integer skip, String sort, String campaignState, String name, String tags, OffsetDateTime createdBefore, OffsetDateTime createdAfter, final ApiCallback<InlineResponse2002> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getCampaignsValidateBeforeCall(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2002>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -5895,7 +5782,7 @@ public class ManagementApi {
      * @param referralId Filter the results by matching them with the Id of a referral, that meaning the coupons that had been created as an effect of the usage of a referral code. (optional)
      * @param recipientIntegrationId Filter results by match with a profile id specified in the coupon&#39;s RecipientIntegrationId field (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
-     * @return InlineResponse2001
+     * @return InlineResponse2004
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -5903,8 +5790,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2001 getCoupons(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, OffsetDateTime startsAfter, OffsetDateTime startsBefore, OffsetDateTime expiresAfter, OffsetDateTime expiresBefore, String valid, String batchId, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch) throws ApiException {
-        ApiResponse<InlineResponse2001> localVarResp = getCouponsWithHttpInfo(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch);
+    public InlineResponse2004 getCoupons(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, OffsetDateTime startsAfter, OffsetDateTime startsBefore, OffsetDateTime expiresAfter, OffsetDateTime expiresBefore, String valid, String batchId, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch) throws ApiException {
+        ApiResponse<InlineResponse2004> localVarResp = getCouponsWithHttpInfo(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch);
         return localVarResp.getData();
     }
 
@@ -5929,7 +5816,7 @@ public class ManagementApi {
      * @param referralId Filter the results by matching them with the Id of a referral, that meaning the coupons that had been created as an effect of the usage of a referral code. (optional)
      * @param recipientIntegrationId Filter results by match with a profile id specified in the coupon&#39;s RecipientIntegrationId field (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
-     * @return ApiResponse&lt;InlineResponse2001&gt;
+     * @return ApiResponse&lt;InlineResponse2004&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -5937,9 +5824,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2001> getCouponsWithHttpInfo(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, OffsetDateTime startsAfter, OffsetDateTime startsBefore, OffsetDateTime expiresAfter, OffsetDateTime expiresBefore, String valid, String batchId, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch) throws ApiException {
+    public ApiResponse<InlineResponse2004> getCouponsWithHttpInfo(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, OffsetDateTime startsAfter, OffsetDateTime startsBefore, OffsetDateTime expiresAfter, OffsetDateTime expiresBefore, String valid, String batchId, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch) throws ApiException {
         okhttp3.Call localVarCall = getCouponsValidateBeforeCall(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -5973,10 +5860,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getCouponsAsync(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, OffsetDateTime startsAfter, OffsetDateTime startsBefore, OffsetDateTime expiresAfter, OffsetDateTime expiresBefore, String valid, String batchId, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
+    public okhttp3.Call getCouponsAsync(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, OffsetDateTime startsAfter, OffsetDateTime startsBefore, OffsetDateTime expiresAfter, OffsetDateTime expiresBefore, String valid, String batchId, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, final ApiCallback<InlineResponse2004> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getCouponsValidateBeforeCall(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -6127,7 +6014,7 @@ public class ManagementApi {
      * @param recipientIntegrationId Filter results by match with a profile id specified in the coupon&#39;s RecipientIntegrationId field (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param batchId Filter results by batches of coupons (optional)
-     * @return InlineResponse2001
+     * @return InlineResponse2004
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -6135,8 +6022,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2001 getCouponsByAttributes(Integer applicationId, Integer campaignId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
-        ApiResponse<InlineResponse2001> localVarResp = getCouponsByAttributesWithHttpInfo(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
+    public InlineResponse2004 getCouponsByAttributes(Integer applicationId, Integer campaignId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
+        ApiResponse<InlineResponse2004> localVarResp = getCouponsByAttributesWithHttpInfo(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
         return localVarResp.getData();
     }
 
@@ -6158,7 +6045,7 @@ public class ManagementApi {
      * @param recipientIntegrationId Filter results by match with a profile id specified in the coupon&#39;s RecipientIntegrationId field (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param batchId Filter results by batches of coupons (optional)
-     * @return ApiResponse&lt;InlineResponse2001&gt;
+     * @return ApiResponse&lt;InlineResponse2004&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -6166,9 +6053,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2001> getCouponsByAttributesWithHttpInfo(Integer applicationId, Integer campaignId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
+    public ApiResponse<InlineResponse2004> getCouponsByAttributesWithHttpInfo(Integer applicationId, Integer campaignId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
         okhttp3.Call localVarCall = getCouponsByAttributesValidateBeforeCall(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -6199,10 +6086,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getCouponsByAttributesAsync(Integer applicationId, Integer campaignId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
+    public okhttp3.Call getCouponsByAttributesAsync(Integer applicationId, Integer campaignId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId, final ApiCallback<InlineResponse2004> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getCouponsByAttributesValidateBeforeCall(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -6351,7 +6238,7 @@ public class ManagementApi {
      * @param batchId Filter results by batches of coupons (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param campaignState Filter results by the state of the campaign. (optional)
-     * @return InlineResponse2001
+     * @return InlineResponse2004
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -6359,8 +6246,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2001 getCouponsByAttributesApplicationWide(Integer applicationId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
-        ApiResponse<InlineResponse2001> localVarResp = getCouponsByAttributesApplicationWideWithHttpInfo(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
+    public InlineResponse2004 getCouponsByAttributesApplicationWide(Integer applicationId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
+        ApiResponse<InlineResponse2004> localVarResp = getCouponsByAttributesApplicationWideWithHttpInfo(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
         return localVarResp.getData();
     }
 
@@ -6382,7 +6269,7 @@ public class ManagementApi {
      * @param batchId Filter results by batches of coupons (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param campaignState Filter results by the state of the campaign. (optional)
-     * @return ApiResponse&lt;InlineResponse2001&gt;
+     * @return ApiResponse&lt;InlineResponse2004&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -6390,9 +6277,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2001> getCouponsByAttributesApplicationWideWithHttpInfo(Integer applicationId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
+    public ApiResponse<InlineResponse2004> getCouponsByAttributesApplicationWideWithHttpInfo(Integer applicationId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
         okhttp3.Call localVarCall = getCouponsByAttributesApplicationWideValidateBeforeCall(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -6423,10 +6310,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getCouponsByAttributesApplicationWideAsync(Integer applicationId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
+    public okhttp3.Call getCouponsByAttributesApplicationWideAsync(Integer applicationId, CouponSearch body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState, final ApiCallback<InlineResponse2004> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getCouponsByAttributesApplicationWideValidateBeforeCall(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -9159,7 +9046,7 @@ public class ManagementApi {
      * @param pageSize The number of items to include in this response. When omitted, the maximum value of 1000 will be used. (optional)
      * @param skip Skips the given number of items when paging through large result sets. (optional)
      * @param sort The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with &#x60;-&#x60; to sort in descending order. (optional)
-     * @return InlineResponse2004
+     * @return InlineResponse2003
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -9167,8 +9054,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2004 getRulesets(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort) throws ApiException {
-        ApiResponse<InlineResponse2004> localVarResp = getRulesetsWithHttpInfo(applicationId, campaignId, pageSize, skip, sort);
+    public InlineResponse2003 getRulesets(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort) throws ApiException {
+        ApiResponse<InlineResponse2003> localVarResp = getRulesetsWithHttpInfo(applicationId, campaignId, pageSize, skip, sort);
         return localVarResp.getData();
     }
 
@@ -9180,7 +9067,7 @@ public class ManagementApi {
      * @param pageSize The number of items to include in this response. When omitted, the maximum value of 1000 will be used. (optional)
      * @param skip Skips the given number of items when paging through large result sets. (optional)
      * @param sort The field by which results should be sorted. Sorting defaults to ascending order, prefix the field name with &#x60;-&#x60; to sort in descending order. (optional)
-     * @return ApiResponse&lt;InlineResponse2004&gt;
+     * @return ApiResponse&lt;InlineResponse2003&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -9188,9 +9075,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2004> getRulesetsWithHttpInfo(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort) throws ApiException {
+    public ApiResponse<InlineResponse2003> getRulesetsWithHttpInfo(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort) throws ApiException {
         okhttp3.Call localVarCall = getRulesetsValidateBeforeCall(applicationId, campaignId, pageSize, skip, sort, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -9211,10 +9098,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getRulesetsAsync(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, final ApiCallback<InlineResponse2004> _callback) throws ApiException {
+    public okhttp3.Call getRulesetsAsync(Integer applicationId, Integer campaignId, Integer pageSize, Integer skip, String sort, final ApiCallback<InlineResponse2003> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getRulesetsValidateBeforeCall(applicationId, campaignId, pageSize, skip, sort, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2003>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -10435,7 +10322,7 @@ public class ManagementApi {
      * @param recipientIntegrationId Filter results by match with a profile id specified in the coupon&#39;s RecipientIntegrationId field (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param batchId Filter results by batches of coupons (optional)
-     * @return InlineResponse2001
+     * @return InlineResponse2004
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -10443,8 +10330,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2001 searchCouponsAdvanced(Integer applicationId, Integer campaignId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
-        ApiResponse<InlineResponse2001> localVarResp = searchCouponsAdvancedWithHttpInfo(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
+    public InlineResponse2004 searchCouponsAdvanced(Integer applicationId, Integer campaignId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
+        ApiResponse<InlineResponse2004> localVarResp = searchCouponsAdvancedWithHttpInfo(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
         return localVarResp.getData();
     }
 
@@ -10466,7 +10353,7 @@ public class ManagementApi {
      * @param recipientIntegrationId Filter results by match with a profile id specified in the coupon&#39;s RecipientIntegrationId field (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param batchId Filter results by batches of coupons (optional)
-     * @return ApiResponse&lt;InlineResponse2001&gt;
+     * @return ApiResponse&lt;InlineResponse2004&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -10474,9 +10361,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2001> searchCouponsAdvancedWithHttpInfo(Integer applicationId, Integer campaignId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
+    public ApiResponse<InlineResponse2004> searchCouponsAdvancedWithHttpInfo(Integer applicationId, Integer campaignId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId) throws ApiException {
         okhttp3.Call localVarCall = searchCouponsAdvancedValidateBeforeCall(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -10507,10 +10394,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call searchCouponsAdvancedAsync(Integer applicationId, Integer campaignId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
+    public okhttp3.Call searchCouponsAdvancedAsync(Integer applicationId, Integer campaignId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, Boolean exactMatch, String batchId, final ApiCallback<InlineResponse2004> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = searchCouponsAdvancedValidateBeforeCall(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -10659,7 +10546,7 @@ public class ManagementApi {
      * @param batchId Filter results by batches of coupons (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param campaignState Filter results by the state of the campaign. (optional)
-     * @return InlineResponse2001
+     * @return InlineResponse2004
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -10667,8 +10554,8 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public InlineResponse2001 searchCouponsAdvancedApplicationWide(Integer applicationId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
-        ApiResponse<InlineResponse2001> localVarResp = searchCouponsAdvancedApplicationWideWithHttpInfo(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
+    public InlineResponse2004 searchCouponsAdvancedApplicationWide(Integer applicationId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
+        ApiResponse<InlineResponse2004> localVarResp = searchCouponsAdvancedApplicationWideWithHttpInfo(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
         return localVarResp.getData();
     }
 
@@ -10690,7 +10577,7 @@ public class ManagementApi {
      * @param batchId Filter results by batches of coupons (optional)
      * @param exactMatch Filter results to an exact case-insensitive matching against the coupon code (optional, default to false)
      * @param campaignState Filter results by the state of the campaign. (optional)
-     * @return ApiResponse&lt;InlineResponse2001&gt;
+     * @return ApiResponse&lt;InlineResponse2004&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -10698,9 +10585,9 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InlineResponse2001> searchCouponsAdvancedApplicationWideWithHttpInfo(Integer applicationId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
+    public ApiResponse<InlineResponse2004> searchCouponsAdvancedApplicationWideWithHttpInfo(Integer applicationId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState) throws ApiException {
         okhttp3.Call localVarCall = searchCouponsAdvancedApplicationWideValidateBeforeCall(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState, null);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -10731,10 +10618,10 @@ public class ManagementApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call searchCouponsAdvancedApplicationWideAsync(Integer applicationId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState, final ApiCallback<InlineResponse2001> _callback) throws ApiException {
+    public okhttp3.Call searchCouponsAdvancedApplicationWideAsync(Integer applicationId, Object body, Integer pageSize, Integer skip, String sort, String value, OffsetDateTime createdBefore, OffsetDateTime createdAfter, String valid, String usable, Integer referralId, String recipientIntegrationId, String batchId, Boolean exactMatch, String campaignState, final ApiCallback<InlineResponse2004> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = searchCouponsAdvancedApplicationWideValidateBeforeCall(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState, _callback);
-        Type localVarReturnType = new TypeToken<InlineResponse2001>(){}.getType();
+        Type localVarReturnType = new TypeToken<InlineResponse2004>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -11555,126 +11442,6 @@ public class ManagementApi {
 
         okhttp3.Call localVarCall = updateCampaignValidateBeforeCall(applicationId, campaignId, body, _callback);
         Type localVarReturnType = new TypeToken<Campaign>(){}.getType();
-        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
-        return localVarCall;
-    }
-    /**
-     * Build call for updateCampaignSet
-     * @param applicationId  (required)
-     * @param body  (required)
-     * @param _callback Callback for upload/download progress
-     * @return Call to execute
-     * @throws ApiException If fail to serialize the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call updateCampaignSetCall(Integer applicationId, NewCampaignSet body, final ApiCallback _callback) throws ApiException {
-        Object localVarPostBody = body;
-
-        // create path and map variables
-        String localVarPath = "/v1/applications/{applicationId}/campaign_set"
-            .replaceAll("\\{" + "applicationId" + "\\}", localVarApiClient.escapeString(applicationId.toString()));
-
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-        Map<String, String> localVarCookieParams = new HashMap<String, String>();
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        final String[] localVarAccepts = {
-            "application/json"
-        };
-        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
-        if (localVarAccept != null) {
-            localVarHeaderParams.put("Accept", localVarAccept);
-        }
-
-        final String[] localVarContentTypes = {
-            "application/json"
-        };
-        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
-        localVarHeaderParams.put("Content-Type", localVarContentType);
-
-        String[] localVarAuthNames = new String[] { "manager_auth" };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
-    }
-
-    @SuppressWarnings("rawtypes")
-    private okhttp3.Call updateCampaignSetValidateBeforeCall(Integer applicationId, NewCampaignSet body, final ApiCallback _callback) throws ApiException {
-        
-        // verify the required parameter 'applicationId' is set
-        if (applicationId == null) {
-            throw new ApiException("Missing the required parameter 'applicationId' when calling updateCampaignSet(Async)");
-        }
-        
-        // verify the required parameter 'body' is set
-        if (body == null) {
-            throw new ApiException("Missing the required parameter 'body' when calling updateCampaignSet(Async)");
-        }
-        
-
-        okhttp3.Call localVarCall = updateCampaignSetCall(applicationId, body, _callback);
-        return localVarCall;
-
-    }
-
-    /**
-     * Update a Campaign Set
-     * 
-     * @param applicationId  (required)
-     * @param body  (required)
-     * @return CampaignSet
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public CampaignSet updateCampaignSet(Integer applicationId, NewCampaignSet body) throws ApiException {
-        ApiResponse<CampaignSet> localVarResp = updateCampaignSetWithHttpInfo(applicationId, body);
-        return localVarResp.getData();
-    }
-
-    /**
-     * Update a Campaign Set
-     * 
-     * @param applicationId  (required)
-     * @param body  (required)
-     * @return ApiResponse&lt;CampaignSet&gt;
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public ApiResponse<CampaignSet> updateCampaignSetWithHttpInfo(Integer applicationId, NewCampaignSet body) throws ApiException {
-        okhttp3.Call localVarCall = updateCampaignSetValidateBeforeCall(applicationId, body, null);
-        Type localVarReturnType = new TypeToken<CampaignSet>(){}.getType();
-        return localVarApiClient.execute(localVarCall, localVarReturnType);
-    }
-
-    /**
-     * Update a Campaign Set (asynchronously)
-     * 
-     * @param applicationId  (required)
-     * @param body  (required)
-     * @param _callback The callback to be executed when the API call finishes
-     * @return The request call
-     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
-     * @http.response.details
-     <table summary="Response Details" border="1">
-        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
-     </table>
-     */
-    public okhttp3.Call updateCampaignSetAsync(Integer applicationId, NewCampaignSet body, final ApiCallback<CampaignSet> _callback) throws ApiException {
-
-        okhttp3.Call localVarCall = updateCampaignSetValidateBeforeCall(applicationId, body, _callback);
-        Type localVarReturnType = new TypeToken<CampaignSet>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }

--- a/src/main/java/one/talon/model/Application.java
+++ b/src/main/java/one/talon/model/Application.java
@@ -129,6 +129,59 @@ public class Application {
   @SerializedName(SERIALIZED_NAME_LIMITS)
   private List<LimitConfig> limits = null;
 
+  /**
+   * Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)
+   */
+  @JsonAdapter(CampaignPriorityEnum.Adapter.class)
+  public enum CampaignPriorityEnum {
+    UNIVERSAL("universal"),
+    
+    STACKABLE("stackable"),
+    
+    EXCLUSIVE("exclusive");
+
+    private String value;
+
+    CampaignPriorityEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static CampaignPriorityEnum fromValue(String value) {
+      for (CampaignPriorityEnum b : CampaignPriorityEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+
+    public static class Adapter extends TypeAdapter<CampaignPriorityEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final CampaignPriorityEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public CampaignPriorityEnum read(final JsonReader jsonReader) throws IOException {
+        String value =  jsonReader.nextString();
+        return CampaignPriorityEnum.fromValue(value);
+      }
+    }
+  }
+
+  public static final String SERIALIZED_NAME_CAMPAIGN_PRIORITY = "campaignPriority";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_PRIORITY)
+  private CampaignPriorityEnum campaignPriority;
+
   public static final String SERIALIZED_NAME_ATTRIBUTES_SETTINGS = "attributesSettings";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES_SETTINGS)
   private AttributesSettings attributesSettings;
@@ -392,6 +445,29 @@ public class Application {
   }
 
 
+  public Application campaignPriority(CampaignPriorityEnum campaignPriority) {
+    
+    this.campaignPriority = campaignPriority;
+    return this;
+  }
+
+   /**
+   * Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)
+   * @return campaignPriority
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)")
+
+  public CampaignPriorityEnum getCampaignPriority() {
+    return campaignPriority;
+  }
+
+
+  public void setCampaignPriority(CampaignPriorityEnum campaignPriority) {
+    this.campaignPriority = campaignPriority;
+  }
+
+
   public Application attributesSettings(AttributesSettings attributesSettings) {
     
     this.attributesSettings = attributesSettings;
@@ -462,13 +538,14 @@ public class Application {
         Objects.equals(this.caseSensitivity, application.caseSensitivity) &&
         Objects.equals(this.attributes, application.attributes) &&
         Objects.equals(this.limits, application.limits) &&
+        Objects.equals(this.campaignPriority, application.campaignPriority) &&
         Objects.equals(this.attributesSettings, application.attributesSettings) &&
         Objects.equals(this.loyaltyPrograms, application.loyaltyPrograms);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, created, modified, accountId, name, description, timezone, currency, caseSensitivity, attributes, limits, attributesSettings, loyaltyPrograms);
+    return Objects.hash(id, created, modified, accountId, name, description, timezone, currency, caseSensitivity, attributes, limits, campaignPriority, attributesSettings, loyaltyPrograms);
   }
 
 
@@ -487,6 +564,7 @@ public class Application {
     sb.append("    caseSensitivity: ").append(toIndentedString(caseSensitivity)).append("\n");
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
     sb.append("    limits: ").append(toIndentedString(limits)).append("\n");
+    sb.append("    campaignPriority: ").append(toIndentedString(campaignPriority)).append("\n");
     sb.append("    attributesSettings: ").append(toIndentedString(attributesSettings)).append("\n");
     sb.append("    loyaltyPrograms: ").append(toIndentedString(loyaltyPrograms)).append("\n");
     sb.append("}");

--- a/src/main/java/one/talon/model/ApplicationSession.java
+++ b/src/main/java/one/talon/model/ApplicationSession.java
@@ -403,8 +403,7 @@ public class ApplicationSession {
    * The total sum of the session before any discounts applied.
    * @return total
   **/
-  @javax.annotation.Nullable
-  @ApiModelProperty(value = "The total sum of the session before any discounts applied.")
+  @ApiModelProperty(required = true, value = "The total sum of the session before any discounts applied.")
 
   public BigDecimal getTotal() {
     return total;

--- a/src/main/java/one/talon/model/CampaignSet.java
+++ b/src/main/java/one/talon/model/CampaignSet.java
@@ -44,6 +44,10 @@ public class CampaignSet {
   @SerializedName(SERIALIZED_NAME_APPLICATION_ID)
   private Integer applicationId;
 
+  public static final String SERIALIZED_NAME_VERSION = "version";
+  @SerializedName(SERIALIZED_NAME_VERSION)
+  private Integer version;
+
   public static final String SERIALIZED_NAME_SET = "set";
   @SerializedName(SERIALIZED_NAME_SET)
   private CampaignSetBranchNode set;
@@ -115,6 +119,29 @@ public class CampaignSet {
   }
 
 
+  public CampaignSet version(Integer version) {
+    
+    this.version = version;
+    return this;
+  }
+
+   /**
+   * Version of the campaign set
+   * minimum: 1
+   * @return version
+  **/
+  @ApiModelProperty(required = true, value = "Version of the campaign set")
+
+  public Integer getVersion() {
+    return version;
+  }
+
+
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
+
   public CampaignSet set(CampaignSetBranchNode set) {
     
     this.set = set;
@@ -149,12 +176,13 @@ public class CampaignSet {
     return Objects.equals(this.id, campaignSet.id) &&
         Objects.equals(this.created, campaignSet.created) &&
         Objects.equals(this.applicationId, campaignSet.applicationId) &&
+        Objects.equals(this.version, campaignSet.version) &&
         Objects.equals(this.set, campaignSet.set);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, created, applicationId, set);
+    return Objects.hash(id, created, applicationId, version, set);
   }
 
 
@@ -165,6 +193,7 @@ public class CampaignSet {
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    created: ").append(toIndentedString(created)).append("\n");
     sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    set: ").append(toIndentedString(set)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/src/main/java/one/talon/model/Coupon.java
+++ b/src/main/java/one/talon/model/Coupon.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 
 /**
@@ -51,6 +52,10 @@ public class Coupon {
   @SerializedName(SERIALIZED_NAME_USAGE_LIMIT)
   private Integer usageLimit;
 
+  public static final String SERIALIZED_NAME_DISCOUNT_LIMIT = "discountLimit";
+  @SerializedName(SERIALIZED_NAME_DISCOUNT_LIMIT)
+  private BigDecimal discountLimit;
+
   public static final String SERIALIZED_NAME_START_DATE = "startDate";
   @SerializedName(SERIALIZED_NAME_START_DATE)
   private OffsetDateTime startDate;
@@ -62,6 +67,14 @@ public class Coupon {
   public static final String SERIALIZED_NAME_USAGE_COUNTER = "usageCounter";
   @SerializedName(SERIALIZED_NAME_USAGE_COUNTER)
   private Integer usageCounter;
+
+  public static final String SERIALIZED_NAME_DISCOUNT_COUNTER = "discountCounter";
+  @SerializedName(SERIALIZED_NAME_DISCOUNT_COUNTER)
+  private BigDecimal discountCounter;
+
+  public static final String SERIALIZED_NAME_DISCOUNT_REMAINDER = "discountRemainder";
+  @SerializedName(SERIALIZED_NAME_DISCOUNT_REMAINDER)
+  private BigDecimal discountRemainder;
 
   public static final String SERIALIZED_NAME_ATTRIBUTES = "attributes";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES)
@@ -200,6 +213,31 @@ public class Coupon {
   }
 
 
+  public Coupon discountLimit(BigDecimal discountLimit) {
+    
+    this.discountLimit = discountLimit;
+    return this;
+  }
+
+   /**
+   * The amount of discounts that can be given with this coupon code. 
+   * minimum: 0
+   * maximum: 999999
+   * @return discountLimit
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The amount of discounts that can be given with this coupon code. ")
+
+  public BigDecimal getDiscountLimit() {
+    return discountLimit;
+  }
+
+
+  public void setDiscountLimit(BigDecimal discountLimit) {
+    this.discountLimit = discountLimit;
+  }
+
+
   public Coupon startDate(OffsetDateTime startDate) {
     
     this.startDate = startDate;
@@ -268,6 +306,52 @@ public class Coupon {
   }
 
 
+  public Coupon discountCounter(BigDecimal discountCounter) {
+    
+    this.discountCounter = discountCounter;
+    return this;
+  }
+
+   /**
+   * The amount of discounts given on rules redeeming this coupon. Only usable if a coupon discount budget was set for this coupon.
+   * @return discountCounter
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The amount of discounts given on rules redeeming this coupon. Only usable if a coupon discount budget was set for this coupon.")
+
+  public BigDecimal getDiscountCounter() {
+    return discountCounter;
+  }
+
+
+  public void setDiscountCounter(BigDecimal discountCounter) {
+    this.discountCounter = discountCounter;
+  }
+
+
+  public Coupon discountRemainder(BigDecimal discountRemainder) {
+    
+    this.discountRemainder = discountRemainder;
+    return this;
+  }
+
+   /**
+   * The remaining discount this coupon can give.
+   * @return discountRemainder
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The remaining discount this coupon can give.")
+
+  public BigDecimal getDiscountRemainder() {
+    return discountRemainder;
+  }
+
+
+  public void setDiscountRemainder(BigDecimal discountRemainder) {
+    this.discountRemainder = discountRemainder;
+  }
+
+
   public Coupon attributes(Object attributes) {
     
     this.attributes = attributes;
@@ -321,11 +405,11 @@ public class Coupon {
   }
 
    /**
-   * The integration ID of a referred customer profile.
+   * The Integration ID of the customer that is allowed to redeem this coupon.
    * @return recipientIntegrationId
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "The integration ID of a referred customer profile.")
+  @ApiModelProperty(value = "The Integration ID of the customer that is allowed to redeem this coupon.")
 
   public String getRecipientIntegrationId() {
     return recipientIntegrationId;
@@ -420,9 +504,12 @@ public class Coupon {
         Objects.equals(this.campaignId, coupon.campaignId) &&
         Objects.equals(this.value, coupon.value) &&
         Objects.equals(this.usageLimit, coupon.usageLimit) &&
+        Objects.equals(this.discountLimit, coupon.discountLimit) &&
         Objects.equals(this.startDate, coupon.startDate) &&
         Objects.equals(this.expiryDate, coupon.expiryDate) &&
         Objects.equals(this.usageCounter, coupon.usageCounter) &&
+        Objects.equals(this.discountCounter, coupon.discountCounter) &&
+        Objects.equals(this.discountRemainder, coupon.discountRemainder) &&
         Objects.equals(this.attributes, coupon.attributes) &&
         Objects.equals(this.referralId, coupon.referralId) &&
         Objects.equals(this.recipientIntegrationId, coupon.recipientIntegrationId) &&
@@ -433,7 +520,7 @@ public class Coupon {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, created, campaignId, value, usageLimit, startDate, expiryDate, usageCounter, attributes, referralId, recipientIntegrationId, importId, reservation, batchId);
+    return Objects.hash(id, created, campaignId, value, usageLimit, discountLimit, startDate, expiryDate, usageCounter, discountCounter, discountRemainder, attributes, referralId, recipientIntegrationId, importId, reservation, batchId);
   }
 
 
@@ -446,9 +533,12 @@ public class Coupon {
     sb.append("    campaignId: ").append(toIndentedString(campaignId)).append("\n");
     sb.append("    value: ").append(toIndentedString(value)).append("\n");
     sb.append("    usageLimit: ").append(toIndentedString(usageLimit)).append("\n");
+    sb.append("    discountLimit: ").append(toIndentedString(discountLimit)).append("\n");
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
     sb.append("    expiryDate: ").append(toIndentedString(expiryDate)).append("\n");
     sb.append("    usageCounter: ").append(toIndentedString(usageCounter)).append("\n");
+    sb.append("    discountCounter: ").append(toIndentedString(discountCounter)).append("\n");
+    sb.append("    discountRemainder: ").append(toIndentedString(discountRemainder)).append("\n");
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
     sb.append("    referralId: ").append(toIndentedString(referralId)).append("\n");
     sb.append("    recipientIntegrationId: ").append(toIndentedString(recipientIntegrationId)).append("\n");

--- a/src/main/java/one/talon/model/CouponConstraints.java
+++ b/src/main/java/one/talon/model/CouponConstraints.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 
 /**
@@ -33,6 +34,10 @@ public class CouponConstraints {
   public static final String SERIALIZED_NAME_USAGE_LIMIT = "usageLimit";
   @SerializedName(SERIALIZED_NAME_USAGE_LIMIT)
   private Integer usageLimit;
+
+  public static final String SERIALIZED_NAME_DISCOUNT_LIMIT = "discountLimit";
+  @SerializedName(SERIALIZED_NAME_DISCOUNT_LIMIT)
+  private BigDecimal discountLimit;
 
   public static final String SERIALIZED_NAME_START_DATE = "startDate";
   @SerializedName(SERIALIZED_NAME_START_DATE)
@@ -65,6 +70,31 @@ public class CouponConstraints {
 
   public void setUsageLimit(Integer usageLimit) {
     this.usageLimit = usageLimit;
+  }
+
+
+  public CouponConstraints discountLimit(BigDecimal discountLimit) {
+    
+    this.discountLimit = discountLimit;
+    return this;
+  }
+
+   /**
+   * The amount of discounts that can be given with this coupon code. 
+   * minimum: 0
+   * maximum: 999999
+   * @return discountLimit
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The amount of discounts that can be given with this coupon code. ")
+
+  public BigDecimal getDiscountLimit() {
+    return discountLimit;
+  }
+
+
+  public void setDiscountLimit(BigDecimal discountLimit) {
+    this.discountLimit = discountLimit;
   }
 
 
@@ -124,13 +154,14 @@ public class CouponConstraints {
     }
     CouponConstraints couponConstraints = (CouponConstraints) o;
     return Objects.equals(this.usageLimit, couponConstraints.usageLimit) &&
+        Objects.equals(this.discountLimit, couponConstraints.discountLimit) &&
         Objects.equals(this.startDate, couponConstraints.startDate) &&
         Objects.equals(this.expiryDate, couponConstraints.expiryDate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(usageLimit, startDate, expiryDate);
+    return Objects.hash(usageLimit, discountLimit, startDate, expiryDate);
   }
 
 
@@ -139,6 +170,7 @@ public class CouponConstraints {
     StringBuilder sb = new StringBuilder();
     sb.append("class CouponConstraints {\n");
     sb.append("    usageLimit: ").append(toIndentedString(usageLimit)).append("\n");
+    sb.append("    discountLimit: ").append(toIndentedString(discountLimit)).append("\n");
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
     sb.append("    expiryDate: ").append(toIndentedString(expiryDate)).append("\n");
     sb.append("}");

--- a/src/main/java/one/talon/model/CustomerInventory.java
+++ b/src/main/java/one/talon/model/CustomerInventory.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import one.talon.model.Coupon;
 import one.talon.model.CustomerProfile;
 import one.talon.model.Referral;
 
@@ -40,6 +41,10 @@ public class CustomerInventory {
   public static final String SERIALIZED_NAME_REFERRALS = "referrals";
   @SerializedName(SERIALIZED_NAME_REFERRALS)
   private List<Referral> referrals = null;
+
+  public static final String SERIALIZED_NAME_COUPONS = "coupons";
+  @SerializedName(SERIALIZED_NAME_COUPONS)
+  private List<Coupon> coupons = null;
 
 
   public CustomerInventory profile(CustomerProfile profile) {
@@ -96,6 +101,37 @@ public class CustomerInventory {
   }
 
 
+  public CustomerInventory coupons(List<Coupon> coupons) {
+    
+    this.coupons = coupons;
+    return this;
+  }
+
+  public CustomerInventory addCouponsItem(Coupon couponsItem) {
+    if (this.coupons == null) {
+      this.coupons = new ArrayList<Coupon>();
+    }
+    this.coupons.add(couponsItem);
+    return this;
+  }
+
+   /**
+   * Get coupons
+   * @return coupons
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public List<Coupon> getCoupons() {
+    return coupons;
+  }
+
+
+  public void setCoupons(List<Coupon> coupons) {
+    this.coupons = coupons;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -106,12 +142,13 @@ public class CustomerInventory {
     }
     CustomerInventory customerInventory = (CustomerInventory) o;
     return Objects.equals(this.profile, customerInventory.profile) &&
-        Objects.equals(this.referrals, customerInventory.referrals);
+        Objects.equals(this.referrals, customerInventory.referrals) &&
+        Objects.equals(this.coupons, customerInventory.coupons);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(profile, referrals);
+    return Objects.hash(profile, referrals, coupons);
   }
 
 
@@ -121,6 +158,7 @@ public class CustomerInventory {
     sb.append("class CustomerInventory {\n");
     sb.append("    profile: ").append(toIndentedString(profile)).append("\n");
     sb.append("    referrals: ").append(toIndentedString(referrals)).append("\n");
+    sb.append("    coupons: ").append(toIndentedString(coupons)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/one/talon/model/CustomerProfileUpdate.java
+++ b/src/main/java/one/talon/model/CustomerProfileUpdate.java
@@ -23,70 +23,37 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import one.talon.model.Campaign;
+import one.talon.model.CustomerProfile;
 
 /**
- * InlineResponse2002
+ * CustomerProfileUpdate
  */
 
-public class InlineResponse2002 {
-  public static final String SERIALIZED_NAME_TOTAL_RESULT_SIZE = "totalResultSize";
-  @SerializedName(SERIALIZED_NAME_TOTAL_RESULT_SIZE)
-  private Integer totalResultSize;
-
-  public static final String SERIALIZED_NAME_DATA = "data";
-  @SerializedName(SERIALIZED_NAME_DATA)
-  private List<Campaign> data = new ArrayList<Campaign>();
+public class CustomerProfileUpdate {
+  public static final String SERIALIZED_NAME_CUSTOMER_PROFILE = "customerProfile";
+  @SerializedName(SERIALIZED_NAME_CUSTOMER_PROFILE)
+  private CustomerProfile customerProfile;
 
 
-  public InlineResponse2002 totalResultSize(Integer totalResultSize) {
+  public CustomerProfileUpdate customerProfile(CustomerProfile customerProfile) {
     
-    this.totalResultSize = totalResultSize;
+    this.customerProfile = customerProfile;
     return this;
   }
 
    /**
-   * Get totalResultSize
-   * @return totalResultSize
+   * Get customerProfile
+   * @return customerProfile
   **/
   @ApiModelProperty(required = true, value = "")
 
-  public Integer getTotalResultSize() {
-    return totalResultSize;
+  public CustomerProfile getCustomerProfile() {
+    return customerProfile;
   }
 
 
-  public void setTotalResultSize(Integer totalResultSize) {
-    this.totalResultSize = totalResultSize;
-  }
-
-
-  public InlineResponse2002 data(List<Campaign> data) {
-    
-    this.data = data;
-    return this;
-  }
-
-  public InlineResponse2002 addDataItem(Campaign dataItem) {
-    this.data.add(dataItem);
-    return this;
-  }
-
-   /**
-   * Get data
-   * @return data
-  **/
-  @ApiModelProperty(required = true, value = "")
-
-  public List<Campaign> getData() {
-    return data;
-  }
-
-
-  public void setData(List<Campaign> data) {
-    this.data = data;
+  public void setCustomerProfile(CustomerProfile customerProfile) {
+    this.customerProfile = customerProfile;
   }
 
 
@@ -98,23 +65,21 @@ public class InlineResponse2002 {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    InlineResponse2002 inlineResponse2002 = (InlineResponse2002) o;
-    return Objects.equals(this.totalResultSize, inlineResponse2002.totalResultSize) &&
-        Objects.equals(this.data, inlineResponse2002.data);
+    CustomerProfileUpdate customerProfileUpdate = (CustomerProfileUpdate) o;
+    return Objects.equals(this.customerProfile, customerProfileUpdate.customerProfile);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(totalResultSize, data);
+    return Objects.hash(customerProfile);
   }
 
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class InlineResponse2002 {\n");
-    sb.append("    totalResultSize: ").append(toIndentedString(totalResultSize)).append("\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
+    sb.append("class CustomerProfileUpdate {\n");
+    sb.append("    customerProfile: ").append(toIndentedString(customerProfile)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/one/talon/model/InlineResponse2001.java
+++ b/src/main/java/one/talon/model/InlineResponse2001.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import one.talon.model.Coupon;
+import one.talon.model.Application;
 
 /**
  * InlineResponse2001
@@ -38,7 +38,7 @@ public class InlineResponse2001 {
 
   public static final String SERIALIZED_NAME_DATA = "data";
   @SerializedName(SERIALIZED_NAME_DATA)
-  private List<Coupon> data = new ArrayList<Coupon>();
+  private List<Application> data = new ArrayList<Application>();
 
 
   public InlineResponse2001 totalResultSize(Integer totalResultSize) {
@@ -63,13 +63,13 @@ public class InlineResponse2001 {
   }
 
 
-  public InlineResponse2001 data(List<Coupon> data) {
+  public InlineResponse2001 data(List<Application> data) {
     
     this.data = data;
     return this;
   }
 
-  public InlineResponse2001 addDataItem(Coupon dataItem) {
+  public InlineResponse2001 addDataItem(Application dataItem) {
     this.data.add(dataItem);
     return this;
   }
@@ -80,12 +80,12 @@ public class InlineResponse2001 {
   **/
   @ApiModelProperty(required = true, value = "")
 
-  public List<Coupon> getData() {
+  public List<Application> getData() {
     return data;
   }
 
 
-  public void setData(List<Coupon> data) {
+  public void setData(List<Application> data) {
     this.data = data;
   }
 

--- a/src/main/java/one/talon/model/InlineResponse2003.java
+++ b/src/main/java/one/talon/model/InlineResponse2003.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import one.talon.model.Campaign;
+import one.talon.model.Ruleset;
 
 /**
  * InlineResponse2003
@@ -38,7 +38,7 @@ public class InlineResponse2003 {
 
   public static final String SERIALIZED_NAME_DATA = "data";
   @SerializedName(SERIALIZED_NAME_DATA)
-  private List<Campaign> data = new ArrayList<Campaign>();
+  private List<Ruleset> data = new ArrayList<Ruleset>();
 
 
   public InlineResponse2003 totalResultSize(Integer totalResultSize) {
@@ -63,13 +63,13 @@ public class InlineResponse2003 {
   }
 
 
-  public InlineResponse2003 data(List<Campaign> data) {
+  public InlineResponse2003 data(List<Ruleset> data) {
     
     this.data = data;
     return this;
   }
 
-  public InlineResponse2003 addDataItem(Campaign dataItem) {
+  public InlineResponse2003 addDataItem(Ruleset dataItem) {
     this.data.add(dataItem);
     return this;
   }
@@ -80,12 +80,12 @@ public class InlineResponse2003 {
   **/
   @ApiModelProperty(required = true, value = "")
 
-  public List<Campaign> getData() {
+  public List<Ruleset> getData() {
     return data;
   }
 
 
-  public void setData(List<Campaign> data) {
+  public void setData(List<Ruleset> data) {
     this.data = data;
   }
 

--- a/src/main/java/one/talon/model/InlineResponse2004.java
+++ b/src/main/java/one/talon/model/InlineResponse2004.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import one.talon.model.Ruleset;
+import one.talon.model.Coupon;
 
 /**
  * InlineResponse2004
@@ -38,7 +38,7 @@ public class InlineResponse2004 {
 
   public static final String SERIALIZED_NAME_DATA = "data";
   @SerializedName(SERIALIZED_NAME_DATA)
-  private List<Ruleset> data = new ArrayList<Ruleset>();
+  private List<Coupon> data = new ArrayList<Coupon>();
 
 
   public InlineResponse2004 totalResultSize(Integer totalResultSize) {
@@ -63,13 +63,13 @@ public class InlineResponse2004 {
   }
 
 
-  public InlineResponse2004 data(List<Ruleset> data) {
+  public InlineResponse2004 data(List<Coupon> data) {
     
     this.data = data;
     return this;
   }
 
-  public InlineResponse2004 addDataItem(Ruleset dataItem) {
+  public InlineResponse2004 addDataItem(Coupon dataItem) {
     this.data.add(dataItem);
     return this;
   }
@@ -80,12 +80,12 @@ public class InlineResponse2004 {
   **/
   @ApiModelProperty(required = true, value = "")
 
-  public List<Ruleset> getData() {
+  public List<Coupon> getData() {
     return data;
   }
 
 
-  public void setData(List<Ruleset> data) {
+  public void setData(List<Coupon> data) {
     this.data = data;
   }
 

--- a/src/main/java/one/talon/model/LoyaltyLedgerEntry.java
+++ b/src/main/java/one/talon/model/LoyaltyLedgerEntry.java
@@ -119,6 +119,10 @@ public class LoyaltyLedgerEntry {
   @SerializedName(SERIALIZED_NAME_SUB_LEDGER_I_D)
   private String subLedgerID;
 
+  public static final String SERIALIZED_NAME_USER_I_D = "userID";
+  @SerializedName(SERIALIZED_NAME_USER_I_D)
+  private Integer userID;
+
 
   public LoyaltyLedgerEntry created(OffsetDateTime created) {
     
@@ -343,6 +347,29 @@ public class LoyaltyLedgerEntry {
   }
 
 
+  public LoyaltyLedgerEntry userID(Integer userID) {
+    
+    this.userID = userID;
+    return this;
+  }
+
+   /**
+   * This is the ID of the user who created this entry, if the addition or subtraction was done manually.
+   * @return userID
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "This is the ID of the user who created this entry, if the addition or subtraction was done manually.")
+
+  public Integer getUserID() {
+    return userID;
+  }
+
+
+  public void setUserID(Integer userID) {
+    this.userID = userID;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -361,12 +388,13 @@ public class LoyaltyLedgerEntry {
         Objects.equals(this.amount, loyaltyLedgerEntry.amount) &&
         Objects.equals(this.expiryDate, loyaltyLedgerEntry.expiryDate) &&
         Objects.equals(this.name, loyaltyLedgerEntry.name) &&
-        Objects.equals(this.subLedgerID, loyaltyLedgerEntry.subLedgerID);
+        Objects.equals(this.subLedgerID, loyaltyLedgerEntry.subLedgerID) &&
+        Objects.equals(this.userID, loyaltyLedgerEntry.userID);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(created, programID, customerProfileID, customerSessionID, eventID, type, amount, expiryDate, name, subLedgerID);
+    return Objects.hash(created, programID, customerProfileID, customerSessionID, eventID, type, amount, expiryDate, name, subLedgerID, userID);
   }
 
 
@@ -384,6 +412,7 @@ public class LoyaltyLedgerEntry {
     sb.append("    expiryDate: ").append(toIndentedString(expiryDate)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    subLedgerID: ").append(toIndentedString(subLedgerID)).append("\n");
+    sb.append("    userID: ").append(toIndentedString(userID)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/one/talon/model/NewApplication.java
+++ b/src/main/java/one/talon/model/NewApplication.java
@@ -111,6 +111,59 @@ public class NewApplication {
   @SerializedName(SERIALIZED_NAME_LIMITS)
   private List<LimitConfig> limits = null;
 
+  /**
+   * Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)
+   */
+  @JsonAdapter(CampaignPriorityEnum.Adapter.class)
+  public enum CampaignPriorityEnum {
+    UNIVERSAL("universal"),
+    
+    STACKABLE("stackable"),
+    
+    EXCLUSIVE("exclusive");
+
+    private String value;
+
+    CampaignPriorityEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static CampaignPriorityEnum fromValue(String value) {
+      for (CampaignPriorityEnum b : CampaignPriorityEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+
+    public static class Adapter extends TypeAdapter<CampaignPriorityEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final CampaignPriorityEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public CampaignPriorityEnum read(final JsonReader jsonReader) throws IOException {
+        String value =  jsonReader.nextString();
+        return CampaignPriorityEnum.fromValue(value);
+      }
+    }
+  }
+
+  public static final String SERIALIZED_NAME_CAMPAIGN_PRIORITY = "campaignPriority";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_PRIORITY)
+  private CampaignPriorityEnum campaignPriority;
+
   public static final String SERIALIZED_NAME_ATTRIBUTES_SETTINGS = "attributesSettings";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES_SETTINGS)
   private AttributesSettings attributesSettings;
@@ -286,6 +339,29 @@ public class NewApplication {
   }
 
 
+  public NewApplication campaignPriority(CampaignPriorityEnum campaignPriority) {
+    
+    this.campaignPriority = campaignPriority;
+    return this;
+  }
+
+   /**
+   * Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)
+   * @return campaignPriority
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)")
+
+  public CampaignPriorityEnum getCampaignPriority() {
+    return campaignPriority;
+  }
+
+
+  public void setCampaignPriority(CampaignPriorityEnum campaignPriority) {
+    this.campaignPriority = campaignPriority;
+  }
+
+
   public NewApplication attributesSettings(AttributesSettings attributesSettings) {
     
     this.attributesSettings = attributesSettings;
@@ -348,13 +424,14 @@ public class NewApplication {
         Objects.equals(this.caseSensitivity, newApplication.caseSensitivity) &&
         Objects.equals(this.attributes, newApplication.attributes) &&
         Objects.equals(this.limits, newApplication.limits) &&
+        Objects.equals(this.campaignPriority, newApplication.campaignPriority) &&
         Objects.equals(this.attributesSettings, newApplication.attributesSettings) &&
         Objects.equals(this.key, newApplication.key);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, timezone, currency, caseSensitivity, attributes, limits, attributesSettings, key);
+    return Objects.hash(name, description, timezone, currency, caseSensitivity, attributes, limits, campaignPriority, attributesSettings, key);
   }
 
 
@@ -369,6 +446,7 @@ public class NewApplication {
     sb.append("    caseSensitivity: ").append(toIndentedString(caseSensitivity)).append("\n");
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
     sb.append("    limits: ").append(toIndentedString(limits)).append("\n");
+    sb.append("    campaignPriority: ").append(toIndentedString(campaignPriority)).append("\n");
     sb.append("    attributesSettings: ").append(toIndentedString(attributesSettings)).append("\n");
     sb.append("    key: ").append(toIndentedString(key)).append("\n");
     sb.append("}");

--- a/src/main/java/one/talon/model/NewCampaignSet.java
+++ b/src/main/java/one/talon/model/NewCampaignSet.java
@@ -35,6 +35,10 @@ public class NewCampaignSet {
   @SerializedName(SERIALIZED_NAME_APPLICATION_ID)
   private Integer applicationId;
 
+  public static final String SERIALIZED_NAME_VERSION = "version";
+  @SerializedName(SERIALIZED_NAME_VERSION)
+  private Integer version;
+
   public static final String SERIALIZED_NAME_SET = "set";
   @SerializedName(SERIALIZED_NAME_SET)
   private CampaignSetBranchNode set;
@@ -59,6 +63,29 @@ public class NewCampaignSet {
 
   public void setApplicationId(Integer applicationId) {
     this.applicationId = applicationId;
+  }
+
+
+  public NewCampaignSet version(Integer version) {
+    
+    this.version = version;
+    return this;
+  }
+
+   /**
+   * Version of the campaign set
+   * minimum: 1
+   * @return version
+  **/
+  @ApiModelProperty(required = true, value = "Version of the campaign set")
+
+  public Integer getVersion() {
+    return version;
+  }
+
+
+  public void setVersion(Integer version) {
+    this.version = version;
   }
 
 
@@ -94,12 +121,13 @@ public class NewCampaignSet {
     }
     NewCampaignSet newCampaignSet = (NewCampaignSet) o;
     return Objects.equals(this.applicationId, newCampaignSet.applicationId) &&
+        Objects.equals(this.version, newCampaignSet.version) &&
         Objects.equals(this.set, newCampaignSet.set);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(applicationId, set);
+    return Objects.hash(applicationId, version, set);
   }
 
 
@@ -108,6 +136,7 @@ public class NewCampaignSet {
     StringBuilder sb = new StringBuilder();
     sb.append("class NewCampaignSet {\n");
     sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    set: ").append(toIndentedString(set)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/src/main/java/one/talon/model/NewCoupons.java
+++ b/src/main/java/one/talon/model/NewCoupons.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.threeten.bp.OffsetDateTime;
@@ -36,6 +37,10 @@ public class NewCoupons {
   public static final String SERIALIZED_NAME_USAGE_LIMIT = "usageLimit";
   @SerializedName(SERIALIZED_NAME_USAGE_LIMIT)
   private Integer usageLimit;
+
+  public static final String SERIALIZED_NAME_DISCOUNT_LIMIT = "discountLimit";
+  @SerializedName(SERIALIZED_NAME_DISCOUNT_LIMIT)
+  private BigDecimal discountLimit;
 
   public static final String SERIALIZED_NAME_START_DATE = "startDate";
   @SerializedName(SERIALIZED_NAME_START_DATE)
@@ -91,6 +96,31 @@ public class NewCoupons {
 
   public void setUsageLimit(Integer usageLimit) {
     this.usageLimit = usageLimit;
+  }
+
+
+  public NewCoupons discountLimit(BigDecimal discountLimit) {
+    
+    this.discountLimit = discountLimit;
+    return this;
+  }
+
+   /**
+   * The amount of discounts that can be given with this coupon code. 
+   * minimum: 0
+   * maximum: 999999
+   * @return discountLimit
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The amount of discounts that can be given with this coupon code. ")
+
+  public BigDecimal getDiscountLimit() {
+    return discountLimit;
+  }
+
+
+  public void setDiscountLimit(BigDecimal discountLimit) {
+    this.discountLimit = discountLimit;
   }
 
 
@@ -290,6 +320,7 @@ public class NewCoupons {
     }
     NewCoupons newCoupons = (NewCoupons) o;
     return Objects.equals(this.usageLimit, newCoupons.usageLimit) &&
+        Objects.equals(this.discountLimit, newCoupons.discountLimit) &&
         Objects.equals(this.startDate, newCoupons.startDate) &&
         Objects.equals(this.expiryDate, newCoupons.expiryDate) &&
         Objects.equals(this.validCharacters, newCoupons.validCharacters) &&
@@ -302,7 +333,7 @@ public class NewCoupons {
 
   @Override
   public int hashCode() {
-    return Objects.hash(usageLimit, startDate, expiryDate, validCharacters, couponPattern, numberOfCoupons, uniquePrefix, attributes, recipientIntegrationId);
+    return Objects.hash(usageLimit, discountLimit, startDate, expiryDate, validCharacters, couponPattern, numberOfCoupons, uniquePrefix, attributes, recipientIntegrationId);
   }
 
 
@@ -311,6 +342,7 @@ public class NewCoupons {
     StringBuilder sb = new StringBuilder();
     sb.append("class NewCoupons {\n");
     sb.append("    usageLimit: ").append(toIndentedString(usageLimit)).append("\n");
+    sb.append("    discountLimit: ").append(toIndentedString(discountLimit)).append("\n");
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
     sb.append("    expiryDate: ").append(toIndentedString(expiryDate)).append("\n");
     sb.append("    validCharacters: ").append(toIndentedString(validCharacters)).append("\n");

--- a/src/main/java/one/talon/model/UpdateApplication.java
+++ b/src/main/java/one/talon/model/UpdateApplication.java
@@ -110,6 +110,59 @@ public class UpdateApplication {
   @SerializedName(SERIALIZED_NAME_LIMITS)
   private List<LimitConfig> limits = null;
 
+  /**
+   * Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)
+   */
+  @JsonAdapter(CampaignPriorityEnum.Adapter.class)
+  public enum CampaignPriorityEnum {
+    UNIVERSAL("universal"),
+    
+    STACKABLE("stackable"),
+    
+    EXCLUSIVE("exclusive");
+
+    private String value;
+
+    CampaignPriorityEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static CampaignPriorityEnum fromValue(String value) {
+      for (CampaignPriorityEnum b : CampaignPriorityEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+
+    public static class Adapter extends TypeAdapter<CampaignPriorityEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final CampaignPriorityEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public CampaignPriorityEnum read(final JsonReader jsonReader) throws IOException {
+        String value =  jsonReader.nextString();
+        return CampaignPriorityEnum.fromValue(value);
+      }
+    }
+  }
+
+  public static final String SERIALIZED_NAME_CAMPAIGN_PRIORITY = "campaignPriority";
+  @SerializedName(SERIALIZED_NAME_CAMPAIGN_PRIORITY)
+  private CampaignPriorityEnum campaignPriority;
+
   public static final String SERIALIZED_NAME_ATTRIBUTES_SETTINGS = "attributesSettings";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES_SETTINGS)
   private AttributesSettings attributesSettings;
@@ -281,6 +334,29 @@ public class UpdateApplication {
   }
 
 
+  public UpdateApplication campaignPriority(CampaignPriorityEnum campaignPriority) {
+    
+    this.campaignPriority = campaignPriority;
+    return this;
+  }
+
+   /**
+   * Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)
+   * @return campaignPriority
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Default priority for campaigns created in this application, can be one of (universal, stackable, exclusive)")
+
+  public CampaignPriorityEnum getCampaignPriority() {
+    return campaignPriority;
+  }
+
+
+  public void setCampaignPriority(CampaignPriorityEnum campaignPriority) {
+    this.campaignPriority = campaignPriority;
+  }
+
+
   public UpdateApplication attributesSettings(AttributesSettings attributesSettings) {
     
     this.attributesSettings = attributesSettings;
@@ -320,12 +396,13 @@ public class UpdateApplication {
         Objects.equals(this.caseSensitivity, updateApplication.caseSensitivity) &&
         Objects.equals(this.attributes, updateApplication.attributes) &&
         Objects.equals(this.limits, updateApplication.limits) &&
+        Objects.equals(this.campaignPriority, updateApplication.campaignPriority) &&
         Objects.equals(this.attributesSettings, updateApplication.attributesSettings);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, timezone, currency, caseSensitivity, attributes, limits, attributesSettings);
+    return Objects.hash(name, description, timezone, currency, caseSensitivity, attributes, limits, campaignPriority, attributesSettings);
   }
 
 
@@ -340,6 +417,7 @@ public class UpdateApplication {
     sb.append("    caseSensitivity: ").append(toIndentedString(caseSensitivity)).append("\n");
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
     sb.append("    limits: ").append(toIndentedString(limits)).append("\n");
+    sb.append("    campaignPriority: ").append(toIndentedString(campaignPriority)).append("\n");
     sb.append("    attributesSettings: ").append(toIndentedString(attributesSettings)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/src/main/java/one/talon/model/UpdateCoupon.java
+++ b/src/main/java/one/talon/model/UpdateCoupon.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 
 /**
@@ -34,6 +35,10 @@ public class UpdateCoupon {
   public static final String SERIALIZED_NAME_USAGE_LIMIT = "usageLimit";
   @SerializedName(SERIALIZED_NAME_USAGE_LIMIT)
   private Integer usageLimit;
+
+  public static final String SERIALIZED_NAME_DISCOUNT_LIMIT = "discountLimit";
+  @SerializedName(SERIALIZED_NAME_DISCOUNT_LIMIT)
+  private BigDecimal discountLimit;
 
   public static final String SERIALIZED_NAME_START_DATE = "startDate";
   @SerializedName(SERIALIZED_NAME_START_DATE)
@@ -74,6 +79,31 @@ public class UpdateCoupon {
 
   public void setUsageLimit(Integer usageLimit) {
     this.usageLimit = usageLimit;
+  }
+
+
+  public UpdateCoupon discountLimit(BigDecimal discountLimit) {
+    
+    this.discountLimit = discountLimit;
+    return this;
+  }
+
+   /**
+   * The amount of discounts that can be given with this coupon code. 
+   * minimum: 0
+   * maximum: 999999
+   * @return discountLimit
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The amount of discounts that can be given with this coupon code. ")
+
+  public BigDecimal getDiscountLimit() {
+    return discountLimit;
+  }
+
+
+  public void setDiscountLimit(BigDecimal discountLimit) {
+    this.discountLimit = discountLimit;
   }
 
 
@@ -179,6 +209,7 @@ public class UpdateCoupon {
     }
     UpdateCoupon updateCoupon = (UpdateCoupon) o;
     return Objects.equals(this.usageLimit, updateCoupon.usageLimit) &&
+        Objects.equals(this.discountLimit, updateCoupon.discountLimit) &&
         Objects.equals(this.startDate, updateCoupon.startDate) &&
         Objects.equals(this.expiryDate, updateCoupon.expiryDate) &&
         Objects.equals(this.recipientIntegrationId, updateCoupon.recipientIntegrationId) &&
@@ -187,7 +218,7 @@ public class UpdateCoupon {
 
   @Override
   public int hashCode() {
-    return Objects.hash(usageLimit, startDate, expiryDate, recipientIntegrationId, attributes);
+    return Objects.hash(usageLimit, discountLimit, startDate, expiryDate, recipientIntegrationId, attributes);
   }
 
 
@@ -196,6 +227,7 @@ public class UpdateCoupon {
     StringBuilder sb = new StringBuilder();
     sb.append("class UpdateCoupon {\n");
     sb.append("    usageLimit: ").append(toIndentedString(usageLimit)).append("\n");
+    sb.append("    discountLimit: ").append(toIndentedString(discountLimit)).append("\n");
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
     sb.append("    expiryDate: ").append(toIndentedString(expiryDate)).append("\n");
     sb.append("    recipientIntegrationId: ").append(toIndentedString(recipientIntegrationId)).append("\n");

--- a/src/main/java/one/talon/model/UpdateCouponBatch.java
+++ b/src/main/java/one/talon/model/UpdateCouponBatch.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 
 /**
@@ -34,6 +35,10 @@ public class UpdateCouponBatch {
   public static final String SERIALIZED_NAME_USAGE_LIMIT = "usageLimit";
   @SerializedName(SERIALIZED_NAME_USAGE_LIMIT)
   private Integer usageLimit;
+
+  public static final String SERIALIZED_NAME_DISCOUNT_LIMIT = "discountLimit";
+  @SerializedName(SERIALIZED_NAME_DISCOUNT_LIMIT)
+  private BigDecimal discountLimit;
 
   public static final String SERIALIZED_NAME_START_DATE = "startDate";
   @SerializedName(SERIALIZED_NAME_START_DATE)
@@ -74,6 +79,31 @@ public class UpdateCouponBatch {
 
   public void setUsageLimit(Integer usageLimit) {
     this.usageLimit = usageLimit;
+  }
+
+
+  public UpdateCouponBatch discountLimit(BigDecimal discountLimit) {
+    
+    this.discountLimit = discountLimit;
+    return this;
+  }
+
+   /**
+   * The amount of discounts that can be given with this coupon code. 
+   * minimum: 0
+   * maximum: 999999
+   * @return discountLimit
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The amount of discounts that can be given with this coupon code. ")
+
+  public BigDecimal getDiscountLimit() {
+    return discountLimit;
+  }
+
+
+  public void setDiscountLimit(BigDecimal discountLimit) {
+    this.discountLimit = discountLimit;
   }
 
 
@@ -178,6 +208,7 @@ public class UpdateCouponBatch {
     }
     UpdateCouponBatch updateCouponBatch = (UpdateCouponBatch) o;
     return Objects.equals(this.usageLimit, updateCouponBatch.usageLimit) &&
+        Objects.equals(this.discountLimit, updateCouponBatch.discountLimit) &&
         Objects.equals(this.startDate, updateCouponBatch.startDate) &&
         Objects.equals(this.expiryDate, updateCouponBatch.expiryDate) &&
         Objects.equals(this.attributes, updateCouponBatch.attributes) &&
@@ -186,7 +217,7 @@ public class UpdateCouponBatch {
 
   @Override
   public int hashCode() {
-    return Objects.hash(usageLimit, startDate, expiryDate, attributes, batchID);
+    return Objects.hash(usageLimit, discountLimit, startDate, expiryDate, attributes, batchID);
   }
 
 
@@ -195,6 +226,7 @@ public class UpdateCouponBatch {
     StringBuilder sb = new StringBuilder();
     sb.append("class UpdateCouponBatch {\n");
     sb.append("    usageLimit: ").append(toIndentedString(usageLimit)).append("\n");
+    sb.append("    discountLimit: ").append(toIndentedString(discountLimit)).append("\n");
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
     sb.append("    expiryDate: ").append(toIndentedString(expiryDate)).append("\n");
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");

--- a/src/test/java/one/talon/api/IntegrationApiTest.java
+++ b/src/test/java/one/talon/api/IntegrationApiTest.java
@@ -17,8 +17,8 @@ import one.talon.ApiException;
 import one.talon.model.Coupon;
 import one.talon.model.CouponReservations;
 import one.talon.model.CustomerInventory;
+import one.talon.model.CustomerProfileUpdate;
 import one.talon.model.InlineResponse200;
-import one.talon.model.InlineResponse2001;
 import one.talon.model.IntegrationRequest;
 import one.talon.model.IntegrationState;
 import one.talon.model.IntegrationStateV2;
@@ -113,7 +113,7 @@ public class IntegrationApiTest {
     /**
      * Get an inventory of all data associated with a specific customer profile.
      *
-     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information and referral codes. In the future, this will be expanded with coupon codes and loyalty points.
+     * Get information regarding entities referencing this customer profile&#39;s integrationId. Currently we support customer profile information, referral codes and reserved coupons. In the future, this will be expanded with loyalty points.
      *
      * @throws ApiException
      *          if the Api call fails
@@ -121,25 +121,10 @@ public class IntegrationApiTest {
     @Test
     public void getCustomerInventoryTest() throws ApiException {
         String integrationId = null;
-        Object profile = null;
-        Object referrals = null;
-        CustomerInventory response = api.getCustomerInventory(integrationId, profile, referrals);
-
-        // TODO: test validations
-    }
-    
-    /**
-     * Get all valid reserved coupons
-     *
-     * Returns all coupons this user is subscribed to that are valid and usable 
-     *
-     * @throws ApiException
-     *          if the Api call fails
-     */
-    @Test
-    public void getReservedCouponsTest() throws ApiException {
-        String integrationId = null;
-        InlineResponse2001 response = api.getReservedCoupons(integrationId);
+        Boolean profile = null;
+        Boolean referrals = null;
+        Boolean coupons = null;
+        CustomerInventory response = api.getCustomerInventory(integrationId, profile, referrals, coupons);
 
         // TODO: test validations
     }
@@ -171,7 +156,8 @@ public class IntegrationApiTest {
     @Test
     public void trackEventTest() throws ApiException {
         NewEvent body = null;
-        IntegrationState response = api.trackEvent(body);
+        Boolean dry = null;
+        IntegrationState response = api.trackEvent(body, dry);
 
         // TODO: test validations
     }
@@ -188,7 +174,25 @@ public class IntegrationApiTest {
     public void updateCustomerProfileTest() throws ApiException {
         String integrationId = null;
         NewCustomerProfile body = null;
-        IntegrationState response = api.updateCustomerProfile(integrationId, body);
+        Boolean dry = null;
+        IntegrationState response = api.updateCustomerProfile(integrationId, body, dry);
+
+        // TODO: test validations
+    }
+    
+    /**
+     * Update a Customer Profile
+     *
+     * Update (or create) a [Customer Profile][].   The &#x60;integrationId&#x60; may be any identifier that will remain stable for the customer. For example, you might use a database ID, an email, or a phone number as the &#x60;integrationId&#x60;. It is vital that this ID **not** change over time, so **don&#39;t** use any identifier that the customer can update themselves. E.g. if your application allows a customer to update their e-mail address, you should instead use a database ID.  [Customer Profile]: /Getting-Started/entities#customer-profile 
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void updateCustomerProfileV2Test() throws ApiException {
+        String customerProfileId = null;
+        NewCustomerProfile body = null;
+        CustomerProfileUpdate response = api.updateCustomerProfileV2(customerProfileId, body);
 
         // TODO: test validations
     }
@@ -205,7 +209,8 @@ public class IntegrationApiTest {
     public void updateCustomerSessionTest() throws ApiException {
         String customerSessionId = null;
         NewCustomerSession body = null;
-        IntegrationState response = api.updateCustomerSession(customerSessionId, body);
+        Boolean dry = null;
+        IntegrationState response = api.updateCustomerSession(customerSessionId, body, dry);
 
         // TODO: test validations
     }
@@ -222,7 +227,8 @@ public class IntegrationApiTest {
     public void updateCustomerSessionV2Test() throws ApiException {
         String customerSessionId = null;
         IntegrationRequest body = null;
-        IntegrationStateV2 response = api.updateCustomerSessionV2(customerSessionId, body);
+        Boolean dry = null;
+        IntegrationStateV2 response = api.updateCustomerSessionV2(customerSessionId, body, dry);
 
         // TODO: test validations
     }

--- a/src/test/java/one/talon/api/ManagementApiTest.java
+++ b/src/test/java/one/talon/api/ManagementApiTest.java
@@ -27,7 +27,6 @@ import java.math.BigDecimal;
 import one.talon.model.Campaign;
 import one.talon.model.CampaignCopy;
 import one.talon.model.CampaignSearch;
-import one.talon.model.CampaignSet;
 import one.talon.model.Coupon;
 import one.talon.model.CouponSearch;
 import one.talon.model.CustomerActivityReport;
@@ -69,7 +68,6 @@ import one.talon.model.LoyaltyProgram;
 import one.talon.model.NewAdditionalCost;
 import one.talon.model.NewAttribute;
 import one.talon.model.NewCampaign;
-import one.talon.model.NewCampaignSet;
 import one.talon.model.NewCoupons;
 import one.talon.model.NewPassword;
 import one.talon.model.NewPasswordEmail;
@@ -131,7 +129,7 @@ public class ManagementApiTest {
         Integer applicationId = null;
         Integer campaignId = null;
         CampaignCopy body = null;
-        InlineResponse2003 response = api.copyCampaignToApplications(applicationId, campaignId, body);
+        InlineResponse2002 response = api.copyCampaignToApplications(applicationId, campaignId, body);
 
         // TODO: test validations
     }
@@ -199,7 +197,7 @@ public class ManagementApiTest {
         Integer campaignId = null;
         NewCoupons body = null;
         String silent = null;
-        InlineResponse2001 response = api.createCoupons(applicationId, campaignId, body, silent);
+        InlineResponse2004 response = api.createCoupons(applicationId, campaignId, body, silent);
 
         // TODO: test validations
     }
@@ -722,7 +720,7 @@ public class ManagementApiTest {
         Integer pageSize = null;
         Integer skip = null;
         String sort = null;
-        InlineResponse2002 response = api.getApplications(pageSize, skip, sort);
+        InlineResponse2001 response = api.getApplications(pageSize, skip, sort);
 
         // TODO: test validations
     }
@@ -814,23 +812,7 @@ public class ManagementApiTest {
         Integer skip = null;
         String sort = null;
         String campaignState = null;
-        InlineResponse2003 response = api.getCampaignByAttributes(applicationId, body, pageSize, skip, sort, campaignState);
-
-        // TODO: test validations
-    }
-    
-    /**
-     * List CampaignSet
-     *
-     * 
-     *
-     * @throws ApiException
-     *          if the Api call fails
-     */
-    @Test
-    public void getCampaignSetTest() throws ApiException {
-        Integer applicationId = null;
-        CampaignSet response = api.getCampaignSet(applicationId);
+        InlineResponse2002 response = api.getCampaignByAttributes(applicationId, body, pageSize, skip, sort, campaignState);
 
         // TODO: test validations
     }
@@ -854,7 +836,7 @@ public class ManagementApiTest {
         String tags = null;
         OffsetDateTime createdBefore = null;
         OffsetDateTime createdAfter = null;
-        InlineResponse2003 response = api.getCampaigns(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter);
+        InlineResponse2002 response = api.getCampaigns(applicationId, pageSize, skip, sort, campaignState, name, tags, createdBefore, createdAfter);
 
         // TODO: test validations
     }
@@ -910,7 +892,7 @@ public class ManagementApiTest {
         Integer referralId = null;
         String recipientIntegrationId = null;
         Boolean exactMatch = null;
-        InlineResponse2001 response = api.getCoupons(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch);
+        InlineResponse2004 response = api.getCoupons(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch);
 
         // TODO: test validations
     }
@@ -940,7 +922,7 @@ public class ManagementApiTest {
         String recipientIntegrationId = null;
         Boolean exactMatch = null;
         String batchId = null;
-        InlineResponse2001 response = api.getCouponsByAttributes(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
+        InlineResponse2004 response = api.getCouponsByAttributes(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
 
         // TODO: test validations
     }
@@ -970,7 +952,7 @@ public class ManagementApiTest {
         String batchId = null;
         Boolean exactMatch = null;
         String campaignState = null;
-        InlineResponse2001 response = api.getCouponsByAttributesApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
+        InlineResponse2004 response = api.getCouponsByAttributesApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
 
         // TODO: test validations
     }
@@ -1354,7 +1336,7 @@ public class ManagementApiTest {
         Integer pageSize = null;
         Integer skip = null;
         String sort = null;
-        InlineResponse2004 response = api.getRulesets(applicationId, campaignId, pageSize, skip, sort);
+        InlineResponse2003 response = api.getRulesets(applicationId, campaignId, pageSize, skip, sort);
 
         // TODO: test validations
     }
@@ -1536,7 +1518,7 @@ public class ManagementApiTest {
         String recipientIntegrationId = null;
         Boolean exactMatch = null;
         String batchId = null;
-        InlineResponse2001 response = api.searchCouponsAdvanced(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
+        InlineResponse2004 response = api.searchCouponsAdvanced(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId);
 
         // TODO: test validations
     }
@@ -1566,7 +1548,7 @@ public class ManagementApiTest {
         String batchId = null;
         Boolean exactMatch = null;
         String campaignState = null;
-        InlineResponse2001 response = api.searchCouponsAdvancedApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
+        InlineResponse2004 response = api.searchCouponsAdvancedApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState);
 
         // TODO: test validations
     }
@@ -1679,23 +1661,6 @@ public class ManagementApiTest {
         Integer campaignId = null;
         UpdateCampaign body = null;
         Campaign response = api.updateCampaign(applicationId, campaignId, body);
-
-        // TODO: test validations
-    }
-    
-    /**
-     * Update a Campaign Set
-     *
-     * 
-     *
-     * @throws ApiException
-     *          if the Api call fails
-     */
-    @Test
-    public void updateCampaignSetTest() throws ApiException {
-        Integer applicationId = null;
-        NewCampaignSet body = null;
-        CampaignSet response = api.updateCampaignSet(applicationId, body);
 
         // TODO: test validations
     }

--- a/src/test/java/one/talon/model/ApplicationTest.java
+++ b/src/test/java/one/talon/model/ApplicationTest.java
@@ -135,6 +135,14 @@ public class ApplicationTest {
     }
 
     /**
+     * Test the property 'campaignPriority'
+     */
+    @Test
+    public void campaignPriorityTest() {
+        // TODO: test campaignPriority
+    }
+
+    /**
      * Test the property 'attributesSettings'
      */
     @Test

--- a/src/test/java/one/talon/model/CouponConstraintsTest.java
+++ b/src/test/java/one/talon/model/CouponConstraintsTest.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -47,6 +48,14 @@ public class CouponConstraintsTest {
     @Test
     public void usageLimitTest() {
         // TODO: test usageLimit
+    }
+
+    /**
+     * Test the property 'discountLimit'
+     */
+    @Test
+    public void discountLimitTest() {
+        // TODO: test discountLimit
     }
 
     /**

--- a/src/test/java/one/talon/model/CouponTest.java
+++ b/src/test/java/one/talon/model/CouponTest.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -82,6 +83,14 @@ public class CouponTest {
     }
 
     /**
+     * Test the property 'discountLimit'
+     */
+    @Test
+    public void discountLimitTest() {
+        // TODO: test discountLimit
+    }
+
+    /**
      * Test the property 'startDate'
      */
     @Test
@@ -103,6 +112,22 @@ public class CouponTest {
     @Test
     public void usageCounterTest() {
         // TODO: test usageCounter
+    }
+
+    /**
+     * Test the property 'discountCounter'
+     */
+    @Test
+    public void discountCounterTest() {
+        // TODO: test discountCounter
+    }
+
+    /**
+     * Test the property 'discountRemainder'
+     */
+    @Test
+    public void discountRemainderTest() {
+        // TODO: test discountRemainder
     }
 
     /**

--- a/src/test/java/one/talon/model/CustomerInventoryTest.java
+++ b/src/test/java/one/talon/model/CustomerInventoryTest.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import one.talon.model.Coupon;
 import one.talon.model.CustomerProfile;
 import one.talon.model.Referral;
 import org.junit.Assert;
@@ -58,6 +59,14 @@ public class CustomerInventoryTest {
     @Test
     public void referralsTest() {
         // TODO: test referrals
+    }
+
+    /**
+     * Test the property 'coupons'
+     */
+    @Test
+    public void couponsTest() {
+        // TODO: test coupons
     }
 
 }

--- a/src/test/java/one/talon/model/CustomerProfileUpdateTest.java
+++ b/src/test/java/one/talon/model/CustomerProfileUpdateTest.java
@@ -21,65 +21,32 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import one.talon.model.CampaignSetBranchNode;
-import org.threeten.bp.OffsetDateTime;
+import one.talon.model.CustomerProfile;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 
 /**
- * Model tests for CampaignSet
+ * Model tests for CustomerProfileUpdate
  */
-public class CampaignSetTest {
-    private final CampaignSet model = new CampaignSet();
+public class CustomerProfileUpdateTest {
+    private final CustomerProfileUpdate model = new CustomerProfileUpdate();
 
     /**
-     * Model tests for CampaignSet
+     * Model tests for CustomerProfileUpdate
      */
     @Test
-    public void testCampaignSet() {
-        // TODO: test CampaignSet
+    public void testCustomerProfileUpdate() {
+        // TODO: test CustomerProfileUpdate
     }
 
     /**
-     * Test the property 'id'
+     * Test the property 'customerProfile'
      */
     @Test
-    public void idTest() {
-        // TODO: test id
-    }
-
-    /**
-     * Test the property 'created'
-     */
-    @Test
-    public void createdTest() {
-        // TODO: test created
-    }
-
-    /**
-     * Test the property 'applicationId'
-     */
-    @Test
-    public void applicationIdTest() {
-        // TODO: test applicationId
-    }
-
-    /**
-     * Test the property 'version'
-     */
-    @Test
-    public void versionTest() {
-        // TODO: test version
-    }
-
-    /**
-     * Test the property 'set'
-     */
-    @Test
-    public void setTest() {
-        // TODO: test set
+    public void customerProfileTest() {
+        // TODO: test customerProfile
     }
 
 }

--- a/src/test/java/one/talon/model/InlineResponse2001Test.java
+++ b/src/test/java/one/talon/model/InlineResponse2001Test.java
@@ -23,7 +23,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import one.talon.model.Coupon;
+import one.talon.model.Application;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/one/talon/model/InlineResponse2002Test.java
+++ b/src/test/java/one/talon/model/InlineResponse2002Test.java
@@ -23,7 +23,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import one.talon.model.Application;
+import one.talon.model.Campaign;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/one/talon/model/InlineResponse2003Test.java
+++ b/src/test/java/one/talon/model/InlineResponse2003Test.java
@@ -23,7 +23,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import one.talon.model.Campaign;
+import one.talon.model.Ruleset;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/one/talon/model/InlineResponse2004Test.java
+++ b/src/test/java/one/talon/model/InlineResponse2004Test.java
@@ -23,7 +23,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import one.talon.model.Ruleset;
+import one.talon.model.Coupon;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/one/talon/model/LoyaltyLedgerEntryTest.java
+++ b/src/test/java/one/talon/model/LoyaltyLedgerEntryTest.java
@@ -122,4 +122,12 @@ public class LoyaltyLedgerEntryTest {
         // TODO: test subLedgerID
     }
 
+    /**
+     * Test the property 'userID'
+     */
+    @Test
+    public void userIDTest() {
+        // TODO: test userID
+    }
+
 }

--- a/src/test/java/one/talon/model/NewApplicationTest.java
+++ b/src/test/java/one/talon/model/NewApplicationTest.java
@@ -101,6 +101,14 @@ public class NewApplicationTest {
     }
 
     /**
+     * Test the property 'campaignPriority'
+     */
+    @Test
+    public void campaignPriorityTest() {
+        // TODO: test campaignPriority
+    }
+
+    /**
      * Test the property 'attributesSettings'
      */
     @Test

--- a/src/test/java/one/talon/model/NewCampaignSetTest.java
+++ b/src/test/java/one/talon/model/NewCampaignSetTest.java
@@ -50,6 +50,14 @@ public class NewCampaignSetTest {
     }
 
     /**
+     * Test the property 'version'
+     */
+    @Test
+    public void versionTest() {
+        // TODO: test version
+    }
+
+    /**
      * Test the property 'set'
      */
     @Test

--- a/src/test/java/one/talon/model/NewCouponsTest.java
+++ b/src/test/java/one/talon/model/NewCouponsTest.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.threeten.bp.OffsetDateTime;
@@ -49,6 +50,14 @@ public class NewCouponsTest {
     @Test
     public void usageLimitTest() {
         // TODO: test usageLimit
+    }
+
+    /**
+     * Test the property 'discountLimit'
+     */
+    @Test
+    public void discountLimitTest() {
+        // TODO: test discountLimit
     }
 
     /**

--- a/src/test/java/one/talon/model/UpdateApplicationTest.java
+++ b/src/test/java/one/talon/model/UpdateApplicationTest.java
@@ -101,6 +101,14 @@ public class UpdateApplicationTest {
     }
 
     /**
+     * Test the property 'campaignPriority'
+     */
+    @Test
+    public void campaignPriorityTest() {
+        // TODO: test campaignPriority
+    }
+
+    /**
      * Test the property 'attributesSettings'
      */
     @Test

--- a/src/test/java/one/talon/model/UpdateCouponBatchTest.java
+++ b/src/test/java/one/talon/model/UpdateCouponBatchTest.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -47,6 +48,14 @@ public class UpdateCouponBatchTest {
     @Test
     public void usageLimitTest() {
         // TODO: test usageLimit
+    }
+
+    /**
+     * Test the property 'discountLimit'
+     */
+    @Test
+    public void discountLimitTest() {
+        // TODO: test discountLimit
     }
 
     /**

--- a/src/test/java/one/talon/model/UpdateCouponTest.java
+++ b/src/test/java/one/talon/model/UpdateCouponTest.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.math.BigDecimal;
 import org.threeten.bp.OffsetDateTime;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -47,6 +48,14 @@ public class UpdateCouponTest {
     @Test
     public void usageLimitTest() {
         // TODO: test usageLimit
+    }
+
+    /**
+     * Test the property 'discountLimit'
+     */
+    @Test
+    public void discountLimitTest() {
+        // TODO: test discountLimit
     }
 
     /**


### PR DESCRIPTION
 - Introduce "dry runs" for Integration API endpoints (See more details below)
 - Add support to retrieve coupons as part of requesting customer profile inventories
 - Add support for setting the `discountLimit` when creating or editing coupons

### Introduce "dry runs" for Integration API endpoints
You can read more about the concept and where this feature could apply in your integration and workflow in our developers documentation center: https://developers.talon.one/Integration-API/dry-requests

**Please Notice** that all current integration request operations (`trackEvent`, `updateCustomerProfile`, `updateCustomerSession`, `updateCustomerSessionV2` ) expects a boolean flag to determine whether this request is a dry run or not.
See code examples in the [README.md](https://github.com/talon-one/TalonOneJavaSdk/blob/v4.1.0/README.md#v1) as for reference.