### PR TITLE
v4.1.1: Fix `LoyaltyLedgerEntry` parsing from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>one.talon</groupId>
   <artifactId>talon-one-client</artifactId>
-  <version>4.1.0</version>
+  <version>4.1.1</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -59,7 +59,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "one.talon:talon-one-client:4.1.0"
+compile "one.talon:talon-one-client:4.1.1"
 ```
 
 ### Others
@@ -72,7 +72,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/talon-one-client-4.1.0.jar`
+* `target/talon-one-client-4.1.1.jar`
 * `target/lib/*.jar`
 
 ## Getting Started
@@ -233,7 +233,6 @@ public class TalonApiTest {
 }
 ```
 
-
 ## Documentation for API Endpoints
 
 All URIs are relative to *http://localhost*
@@ -265,7 +264,7 @@ Class | Method | HTTP request | Description
 *ManagementApi* | [**deleteCoupons**](docs/ManagementApi.md#deleteCoupons) | **DELETE** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | Delete Coupons
 *ManagementApi* | [**deleteReferral**](docs/ManagementApi.md#deleteReferral) | **DELETE** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals/{referralId} | Delete one Referral
 *ManagementApi* | [**deleteRuleset**](docs/ManagementApi.md#deleteRuleset) | **DELETE** /v1/applications/{applicationId}/campaigns/{campaignId}/rulesets/{rulesetId} | Delete a Ruleset
-*ManagementApi* | [**getAccessLogs**](docs/ManagementApi.md#getAccessLogs) | **GET** /v1/applications/{applicationId}/access_logs | Get access logs for application
+*ManagementApi* | [**getAccessLogs**](docs/ManagementApi.md#getAccessLogs) | **GET** /v1/applications/{applicationId}/access_logs | Get access logs for application (with total count)
 *ManagementApi* | [**getAccessLogsWithoutTotalCount**](docs/ManagementApi.md#getAccessLogsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/access_logs/no_total | Get access logs for application
 *ManagementApi* | [**getAccount**](docs/ManagementApi.md#getAccount) | **GET** /v1/accounts/{accountId} | Get Account Details
 *ManagementApi* | [**getAccountAnalytics**](docs/ManagementApi.md#getAccountAnalytics) | **GET** /v1/accounts/{accountId}/analytics | Get Account Analytics
@@ -277,9 +276,9 @@ Class | Method | HTTP request | Description
 *ManagementApi* | [**getApplicationApiHealth**](docs/ManagementApi.md#getApplicationApiHealth) | **GET** /v1/applications/{applicationId}/health_report | Get report of health of application API
 *ManagementApi* | [**getApplicationCustomer**](docs/ManagementApi.md#getApplicationCustomer) | **GET** /v1/applications/{applicationId}/customers/{customerId} | Get Application Customer
 *ManagementApi* | [**getApplicationCustomers**](docs/ManagementApi.md#getApplicationCustomers) | **GET** /v1/applications/{applicationId}/customers | List Application Customers
-*ManagementApi* | [**getApplicationCustomersByAttributes**](docs/ManagementApi.md#getApplicationCustomersByAttributes) | **POST** /v1/application_customer_search | Get a list of the customer profiles that match the given attributes
+*ManagementApi* | [**getApplicationCustomersByAttributes**](docs/ManagementApi.md#getApplicationCustomersByAttributes) | **POST** /v1/application_customer_search | Get a list of the customer profiles that match the given attributes (with total count)
 *ManagementApi* | [**getApplicationEventTypes**](docs/ManagementApi.md#getApplicationEventTypes) | **GET** /v1/applications/{applicationId}/event_types | List Applications Event Types
-*ManagementApi* | [**getApplicationEvents**](docs/ManagementApi.md#getApplicationEvents) | **GET** /v1/applications/{applicationId}/events | List Applications Events
+*ManagementApi* | [**getApplicationEvents**](docs/ManagementApi.md#getApplicationEvents) | **GET** /v1/applications/{applicationId}/events | List Applications Events (with total count)
 *ManagementApi* | [**getApplicationEventsWithoutTotalCount**](docs/ManagementApi.md#getApplicationEventsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/events/no_total | List Applications Events
 *ManagementApi* | [**getApplicationSession**](docs/ManagementApi.md#getApplicationSession) | **GET** /v1/applications/{applicationId}/sessions/{sessionId} | Get Application Session
 *ManagementApi* | [**getApplicationSessions**](docs/ManagementApi.md#getApplicationSessions) | **GET** /v1/applications/{applicationId}/sessions | List Application Sessions
@@ -291,12 +290,12 @@ Class | Method | HTTP request | Description
 *ManagementApi* | [**getCampaignByAttributes**](docs/ManagementApi.md#getCampaignByAttributes) | **POST** /v1/applications/{applicationId}/campaigns_search | Get a list of all campaigns that match the given attributes
 *ManagementApi* | [**getCampaigns**](docs/ManagementApi.md#getCampaigns) | **GET** /v1/applications/{applicationId}/campaigns | List your Campaigns
 *ManagementApi* | [**getChanges**](docs/ManagementApi.md#getChanges) | **GET** /v1/changes | Get audit log for an account
-*ManagementApi* | [**getCoupons**](docs/ManagementApi.md#getCoupons) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | List Coupons
+*ManagementApi* | [**getCoupons**](docs/ManagementApi.md#getCoupons) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | List Coupons (with total count)
 *ManagementApi* | [**getCouponsByAttributes**](docs/ManagementApi.md#getCouponsByAttributes) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search | Get a list of the coupons that match the given attributes
-*ManagementApi* | [**getCouponsByAttributesApplicationWide**](docs/ManagementApi.md#getCouponsByAttributesApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search | Get a list of the coupons that match the given attributes in all active campaigns of an application
+*ManagementApi* | [**getCouponsByAttributesApplicationWide**](docs/ManagementApi.md#getCouponsByAttributesApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search | Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
 *ManagementApi* | [**getCouponsWithoutTotalCount**](docs/ManagementApi.md#getCouponsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons/no_total | List Coupons
 *ManagementApi* | [**getCustomerActivityReport**](docs/ManagementApi.md#getCustomerActivityReport) | **GET** /v1/applications/{applicationId}/customer_activity_reports/{customerId} | Get Activity Report for Single Customer
-*ManagementApi* | [**getCustomerActivityReports**](docs/ManagementApi.md#getCustomerActivityReports) | **GET** /v1/applications/{applicationId}/customer_activity_reports | Get Activity Reports for Application Customers
+*ManagementApi* | [**getCustomerActivityReports**](docs/ManagementApi.md#getCustomerActivityReports) | **GET** /v1/applications/{applicationId}/customer_activity_reports | Get Activity Reports for Application Customers (with total count)
 *ManagementApi* | [**getCustomerActivityReportsWithoutTotalCount**](docs/ManagementApi.md#getCustomerActivityReportsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/customer_activity_reports/no_total | Get Activity Reports for Application Customers
 *ManagementApi* | [**getCustomerAnalytics**](docs/ManagementApi.md#getCustomerAnalytics) | **GET** /v1/applications/{applicationId}/customers/{customerId}/analytics | Get Analytics Report for a Customer
 *ManagementApi* | [**getCustomerProfile**](docs/ManagementApi.md#getCustomerProfile) | **GET** /v1/customers/{customerId} | Get Customer Profile
@@ -308,7 +307,7 @@ Class | Method | HTTP request | Description
 *ManagementApi* | [**getLoyaltyPoints**](docs/ManagementApi.md#getLoyaltyPoints) | **GET** /v1/loyalty_programs/{programID}/profile/{integrationID} | get the Loyalty Ledger for this integrationID
 *ManagementApi* | [**getLoyaltyProgram**](docs/ManagementApi.md#getLoyaltyProgram) | **GET** /v1/loyalty_programs/{programID} | Get a loyalty program
 *ManagementApi* | [**getLoyaltyPrograms**](docs/ManagementApi.md#getLoyaltyPrograms) | **GET** /v1/loyalty_programs | List all loyalty Programs
-*ManagementApi* | [**getReferrals**](docs/ManagementApi.md#getReferrals) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals | List Referrals
+*ManagementApi* | [**getReferrals**](docs/ManagementApi.md#getReferrals) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals | List Referrals (with total count)
 *ManagementApi* | [**getReferralsWithoutTotalCount**](docs/ManagementApi.md#getReferralsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals/no_total | List Referrals
 *ManagementApi* | [**getRole**](docs/ManagementApi.md#getRole) | **GET** /v1/roles/{roleId} | Get information for the specified role.
 *ManagementApi* | [**getRuleset**](docs/ManagementApi.md#getRuleset) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/rulesets/{rulesetId} | Get a Ruleset
@@ -321,8 +320,8 @@ Class | Method | HTTP request | Description
 *ManagementApi* | [**getWebhooks**](docs/ManagementApi.md#getWebhooks) | **GET** /v1/webhooks | List Webhooks
 *ManagementApi* | [**removeLoyaltyPoints**](docs/ManagementApi.md#removeLoyaltyPoints) | **PUT** /v1/loyalty_programs/{programID}/profile/{integrationID}/deduct_points | Deduct points in a certain loyalty program for the specified customer
 *ManagementApi* | [**resetPassword**](docs/ManagementApi.md#resetPassword) | **POST** /v1/reset_password | Reset password
-*ManagementApi* | [**searchCouponsAdvanced**](docs/ManagementApi.md#searchCouponsAdvanced) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search_advanced | Get a list of the coupons that match the given attributes
-*ManagementApi* | [**searchCouponsAdvancedApplicationWide**](docs/ManagementApi.md#searchCouponsAdvancedApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search_advanced | Get a list of the coupons that match the given attributes in all active campaigns of an application
+*ManagementApi* | [**searchCouponsAdvanced**](docs/ManagementApi.md#searchCouponsAdvanced) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search_advanced | Get a list of the coupons that match the given attributes (with total count)
+*ManagementApi* | [**searchCouponsAdvancedApplicationWide**](docs/ManagementApi.md#searchCouponsAdvancedApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search_advanced | Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
 *ManagementApi* | [**searchCouponsAdvancedApplicationWideWithoutTotalCount**](docs/ManagementApi.md#searchCouponsAdvancedApplicationWideWithoutTotalCount) | **POST** /v1/applications/{applicationId}/coupons_search_advanced/no_total | Get a list of the coupons that match the given attributes in all active campaigns of an application
 *ManagementApi* | [**searchCouponsAdvancedWithoutTotalCount**](docs/ManagementApi.md#searchCouponsAdvancedWithoutTotalCount) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search_advanced/no_total | Get a list of the coupons that match the given attributes
 *ManagementApi* | [**updateAdditionalCost**](docs/ManagementApi.md#updateAdditionalCost) | **PUT** /v1/additional_costs/{additionalCostId} | Update an additional cost

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'one.talon'
-version = '4.1.0'
+version = '4.1.1'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "one.talon",
     name := "talon-one-client",
-    version := "4.1.0",
+    version := "4.1.1",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/docs/LoyaltyLedgerEntry.md
+++ b/docs/LoyaltyLedgerEntry.md
@@ -12,21 +12,12 @@ Name | Type | Description | Notes
 **customerProfileID** | **String** |  | 
 **customerSessionID** | **String** |  |  [optional]
 **eventID** | **Integer** |  |  [optional]
-**type** | [**TypeEnum**](#TypeEnum) |  | 
+**type** | **String** | The type of the ledger transaction. Possible values are addition, subtraction, expire or expiring (for expiring points ledgers)  | 
 **amount** | [**BigDecimal**](BigDecimal.md) |  | 
 **expiryDate** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **name** | **String** | A name referencing the condition or effect that added this entry, or the specific name provided in an API call. | 
 **subLedgerID** | **String** | This specifies if we are adding loyalty points to the main ledger or a subledger | 
 **userID** | **Integer** | This is the ID of the user who created this entry, if the addition or subtraction was done manually. |  [optional]
-
-
-
-## Enum: TypeEnum
-
-Name | Value
----- | -----
-ADDITION | &quot;addition&quot;
-SUBTRACTION | &quot;subtraction&quot;
 
 
 

--- a/docs/ManagementApi.md
+++ b/docs/ManagementApi.md
@@ -18,7 +18,7 @@ Method | HTTP request | Description
 [**deleteCoupons**](ManagementApi.md#deleteCoupons) | **DELETE** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | Delete Coupons
 [**deleteReferral**](ManagementApi.md#deleteReferral) | **DELETE** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals/{referralId} | Delete one Referral
 [**deleteRuleset**](ManagementApi.md#deleteRuleset) | **DELETE** /v1/applications/{applicationId}/campaigns/{campaignId}/rulesets/{rulesetId} | Delete a Ruleset
-[**getAccessLogs**](ManagementApi.md#getAccessLogs) | **GET** /v1/applications/{applicationId}/access_logs | Get access logs for application
+[**getAccessLogs**](ManagementApi.md#getAccessLogs) | **GET** /v1/applications/{applicationId}/access_logs | Get access logs for application (with total count)
 [**getAccessLogsWithoutTotalCount**](ManagementApi.md#getAccessLogsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/access_logs/no_total | Get access logs for application
 [**getAccount**](ManagementApi.md#getAccount) | **GET** /v1/accounts/{accountId} | Get Account Details
 [**getAccountAnalytics**](ManagementApi.md#getAccountAnalytics) | **GET** /v1/accounts/{accountId}/analytics | Get Account Analytics
@@ -30,9 +30,9 @@ Method | HTTP request | Description
 [**getApplicationApiHealth**](ManagementApi.md#getApplicationApiHealth) | **GET** /v1/applications/{applicationId}/health_report | Get report of health of application API
 [**getApplicationCustomer**](ManagementApi.md#getApplicationCustomer) | **GET** /v1/applications/{applicationId}/customers/{customerId} | Get Application Customer
 [**getApplicationCustomers**](ManagementApi.md#getApplicationCustomers) | **GET** /v1/applications/{applicationId}/customers | List Application Customers
-[**getApplicationCustomersByAttributes**](ManagementApi.md#getApplicationCustomersByAttributes) | **POST** /v1/application_customer_search | Get a list of the customer profiles that match the given attributes
+[**getApplicationCustomersByAttributes**](ManagementApi.md#getApplicationCustomersByAttributes) | **POST** /v1/application_customer_search | Get a list of the customer profiles that match the given attributes (with total count)
 [**getApplicationEventTypes**](ManagementApi.md#getApplicationEventTypes) | **GET** /v1/applications/{applicationId}/event_types | List Applications Event Types
-[**getApplicationEvents**](ManagementApi.md#getApplicationEvents) | **GET** /v1/applications/{applicationId}/events | List Applications Events
+[**getApplicationEvents**](ManagementApi.md#getApplicationEvents) | **GET** /v1/applications/{applicationId}/events | List Applications Events (with total count)
 [**getApplicationEventsWithoutTotalCount**](ManagementApi.md#getApplicationEventsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/events/no_total | List Applications Events
 [**getApplicationSession**](ManagementApi.md#getApplicationSession) | **GET** /v1/applications/{applicationId}/sessions/{sessionId} | Get Application Session
 [**getApplicationSessions**](ManagementApi.md#getApplicationSessions) | **GET** /v1/applications/{applicationId}/sessions | List Application Sessions
@@ -44,12 +44,12 @@ Method | HTTP request | Description
 [**getCampaignByAttributes**](ManagementApi.md#getCampaignByAttributes) | **POST** /v1/applications/{applicationId}/campaigns_search | Get a list of all campaigns that match the given attributes
 [**getCampaigns**](ManagementApi.md#getCampaigns) | **GET** /v1/applications/{applicationId}/campaigns | List your Campaigns
 [**getChanges**](ManagementApi.md#getChanges) | **GET** /v1/changes | Get audit log for an account
-[**getCoupons**](ManagementApi.md#getCoupons) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | List Coupons
+[**getCoupons**](ManagementApi.md#getCoupons) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons | List Coupons (with total count)
 [**getCouponsByAttributes**](ManagementApi.md#getCouponsByAttributes) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search | Get a list of the coupons that match the given attributes
-[**getCouponsByAttributesApplicationWide**](ManagementApi.md#getCouponsByAttributesApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search | Get a list of the coupons that match the given attributes in all active campaigns of an application
+[**getCouponsByAttributesApplicationWide**](ManagementApi.md#getCouponsByAttributesApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search | Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
 [**getCouponsWithoutTotalCount**](ManagementApi.md#getCouponsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons/no_total | List Coupons
 [**getCustomerActivityReport**](ManagementApi.md#getCustomerActivityReport) | **GET** /v1/applications/{applicationId}/customer_activity_reports/{customerId} | Get Activity Report for Single Customer
-[**getCustomerActivityReports**](ManagementApi.md#getCustomerActivityReports) | **GET** /v1/applications/{applicationId}/customer_activity_reports | Get Activity Reports for Application Customers
+[**getCustomerActivityReports**](ManagementApi.md#getCustomerActivityReports) | **GET** /v1/applications/{applicationId}/customer_activity_reports | Get Activity Reports for Application Customers (with total count)
 [**getCustomerActivityReportsWithoutTotalCount**](ManagementApi.md#getCustomerActivityReportsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/customer_activity_reports/no_total | Get Activity Reports for Application Customers
 [**getCustomerAnalytics**](ManagementApi.md#getCustomerAnalytics) | **GET** /v1/applications/{applicationId}/customers/{customerId}/analytics | Get Analytics Report for a Customer
 [**getCustomerProfile**](ManagementApi.md#getCustomerProfile) | **GET** /v1/customers/{customerId} | Get Customer Profile
@@ -61,7 +61,7 @@ Method | HTTP request | Description
 [**getLoyaltyPoints**](ManagementApi.md#getLoyaltyPoints) | **GET** /v1/loyalty_programs/{programID}/profile/{integrationID} | get the Loyalty Ledger for this integrationID
 [**getLoyaltyProgram**](ManagementApi.md#getLoyaltyProgram) | **GET** /v1/loyalty_programs/{programID} | Get a loyalty program
 [**getLoyaltyPrograms**](ManagementApi.md#getLoyaltyPrograms) | **GET** /v1/loyalty_programs | List all loyalty Programs
-[**getReferrals**](ManagementApi.md#getReferrals) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals | List Referrals
+[**getReferrals**](ManagementApi.md#getReferrals) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals | List Referrals (with total count)
 [**getReferralsWithoutTotalCount**](ManagementApi.md#getReferralsWithoutTotalCount) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/referrals/no_total | List Referrals
 [**getRole**](ManagementApi.md#getRole) | **GET** /v1/roles/{roleId} | Get information for the specified role.
 [**getRuleset**](ManagementApi.md#getRuleset) | **GET** /v1/applications/{applicationId}/campaigns/{campaignId}/rulesets/{rulesetId} | Get a Ruleset
@@ -74,8 +74,8 @@ Method | HTTP request | Description
 [**getWebhooks**](ManagementApi.md#getWebhooks) | **GET** /v1/webhooks | List Webhooks
 [**removeLoyaltyPoints**](ManagementApi.md#removeLoyaltyPoints) | **PUT** /v1/loyalty_programs/{programID}/profile/{integrationID}/deduct_points | Deduct points in a certain loyalty program for the specified customer
 [**resetPassword**](ManagementApi.md#resetPassword) | **POST** /v1/reset_password | Reset password
-[**searchCouponsAdvanced**](ManagementApi.md#searchCouponsAdvanced) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search_advanced | Get a list of the coupons that match the given attributes
-[**searchCouponsAdvancedApplicationWide**](ManagementApi.md#searchCouponsAdvancedApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search_advanced | Get a list of the coupons that match the given attributes in all active campaigns of an application
+[**searchCouponsAdvanced**](ManagementApi.md#searchCouponsAdvanced) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search_advanced | Get a list of the coupons that match the given attributes (with total count)
+[**searchCouponsAdvancedApplicationWide**](ManagementApi.md#searchCouponsAdvancedApplicationWide) | **POST** /v1/applications/{applicationId}/coupons_search_advanced | Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
 [**searchCouponsAdvancedApplicationWideWithoutTotalCount**](ManagementApi.md#searchCouponsAdvancedApplicationWideWithoutTotalCount) | **POST** /v1/applications/{applicationId}/coupons_search_advanced/no_total | Get a list of the coupons that match the given attributes in all active campaigns of an application
 [**searchCouponsAdvancedWithoutTotalCount**](ManagementApi.md#searchCouponsAdvancedWithoutTotalCount) | **POST** /v1/applications/{applicationId}/campaigns/{campaignId}/coupons_search_advanced/no_total | Get a list of the coupons that match the given attributes
 [**updateAdditionalCost**](ManagementApi.md#updateAdditionalCost) | **PUT** /v1/additional_costs/{additionalCostId} | Update an additional cost
@@ -1095,7 +1095,7 @@ null (empty response body)
 # **getAccessLogs**
 > InlineResponse2009 getAccessLogs(applicationId, rangeStart, rangeEnd, path, method, status, pageSize, skip, sort)
 
-Get access logs for application
+Get access logs for application (with total count)
 
 ### Example
 ```java
@@ -1959,7 +1959,7 @@ Name | Type | Description  | Notes
 # **getApplicationCustomersByAttributes**
 > InlineResponse20013 getApplicationCustomersByAttributes(body)
 
-Get a list of the customer profiles that match the given attributes
+Get a list of the customer profiles that match the given attributes (with total count)
 
 Gets a list of all the customer profiles for the account that exactly match a set of attributes.  The match is successful if all the attributes of the request are found in a profile, even if the profile has more attributes that are not present on the request.  [Customer Profile]: https://help.talon.one/hc/en-us/articles/360005130739-Data-Model#CustomerProfile 
 
@@ -2103,7 +2103,7 @@ Name | Type | Description  | Notes
 # **getApplicationEvents**
 > InlineResponse20017 getApplicationEvents(applicationId, pageSize, skip, sort, type, createdBefore, createdAfter, session, profile, customerName, customerEmail, couponCode, referralCode, ruleQuery, campaignQuery)
 
-List Applications Events
+List Applications Events (with total count)
 
 Lists all events recorded for an application. 
 
@@ -3055,7 +3055,7 @@ Name | Type | Description  | Notes
 # **getCoupons**
 > InlineResponse2004 getCoupons(applicationId, campaignId, pageSize, skip, sort, value, createdBefore, createdAfter, startsAfter, startsBefore, expiresAfter, expiresBefore, valid, batchId, usable, referralId, recipientIntegrationId, exactMatch)
 
-List Coupons
+List Coupons (with total count)
 
 ### Example
 ```java
@@ -3253,7 +3253,7 @@ Name | Type | Description  | Notes
 # **getCouponsByAttributesApplicationWide**
 > InlineResponse2004 getCouponsByAttributesApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState)
 
-Get a list of the coupons that match the given attributes in all active campaigns of an application
+Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
 
 Gets a list of all the coupons with attributes matching the query criteria Application wide 
 
@@ -3522,7 +3522,7 @@ Name | Type | Description  | Notes
 # **getCustomerActivityReports**
 > InlineResponse20014 getCustomerActivityReports(rangeStart, rangeEnd, applicationId, pageSize, skip, sort, name, integrationId, campaignName, advocateName)
 
-Get Activity Reports for Application Customers
+Get Activity Reports for Application Customers (with total count)
 
 Fetch summary reports for all application customers based on a time range
 
@@ -4412,7 +4412,7 @@ This endpoint does not need any parameter.
 # **getReferrals**
 > InlineResponse2006 getReferrals(applicationId, campaignId, pageSize, skip, sort, code, createdBefore, createdAfter, valid, usable, advocate)
 
-List Referrals
+List Referrals (with total count)
 
 ### Example
 ```java
@@ -5392,7 +5392,7 @@ Name | Type | Description  | Notes
 # **searchCouponsAdvanced**
 > InlineResponse2004 searchCouponsAdvanced(applicationId, campaignId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, exactMatch, batchId)
 
-Get a list of the coupons that match the given attributes
+Get a list of the coupons that match the given attributes (with total count)
 
 Gets a list of all the coupons with attributes matching the query criteria 
 
@@ -5489,7 +5489,7 @@ Name | Type | Description  | Notes
 # **searchCouponsAdvancedApplicationWide**
 > InlineResponse2004 searchCouponsAdvancedApplicationWide(applicationId, body, pageSize, skip, sort, value, createdBefore, createdAfter, valid, usable, referralId, recipientIntegrationId, batchId, exactMatch, campaignState)
 
-Get a list of the coupons that match the given attributes in all active campaigns of an application
+Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
 
 Gets a list of all the coupons with attributes matching the query criteria in all active campaigns of an application 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>talon-one-client</artifactId>
     <packaging>jar</packaging>
     <name>talon-one-client</name>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
     <url>https://github.com/talon-one/maven-artefacts</url>
     <description>Talon.One unified JAVA SDK. It allows for programmatic access to the integration and management API with their respective authentication strategies</description>
     <scm>

--- a/src/main/java/one/talon/ApiClient.java
+++ b/src/main/java/one/talon/ApiClient.java
@@ -128,7 +128,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("OpenAPI-Generator/4.1.0/java");
+        setUserAgent("OpenAPI-Generator/4.1.1/java");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/one/talon/api/ManagementApi.java
+++ b/src/main/java/one/talon/api/ManagementApi.java
@@ -2034,7 +2034,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get access logs for application
+     * Get access logs for application (with total count)
      * 
      * @param applicationId  (required)
      * @param rangeStart Only return results from after this timestamp, must be an RFC3339 timestamp string (required)
@@ -2059,7 +2059,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get access logs for application
+     * Get access logs for application (with total count)
      * 
      * @param applicationId  (required)
      * @param rangeStart Only return results from after this timestamp, must be an RFC3339 timestamp string (required)
@@ -2085,7 +2085,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get access logs for application (asynchronously)
+     * Get access logs for application (with total count) (asynchronously)
      * 
      * @param applicationId  (required)
      * @param rangeStart Only return results from after this timestamp, must be an RFC3339 timestamp string (required)
@@ -3544,7 +3544,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the customer profiles that match the given attributes
+     * Get a list of the customer profiles that match the given attributes (with total count)
      * Gets a list of all the customer profiles for the account that exactly match a set of attributes.  The match is successful if all the attributes of the request are found in a profile, even if the profile has more attributes that are not present on the request.  [Customer Profile]: https://help.talon.one/hc/en-us/articles/360005130739-Data-Model#CustomerProfile 
      * @param body  (required)
      * @return InlineResponse20013
@@ -3563,7 +3563,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the customer profiles that match the given attributes
+     * Get a list of the customer profiles that match the given attributes (with total count)
      * Gets a list of all the customer profiles for the account that exactly match a set of attributes.  The match is successful if all the attributes of the request are found in a profile, even if the profile has more attributes that are not present on the request.  [Customer Profile]: https://help.talon.one/hc/en-us/articles/360005130739-Data-Model#CustomerProfile 
      * @param body  (required)
      * @return ApiResponse&lt;InlineResponse20013&gt;
@@ -3583,7 +3583,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the customer profiles that match the given attributes (asynchronously)
+     * Get a list of the customer profiles that match the given attributes (with total count) (asynchronously)
      * Gets a list of all the customer profiles for the account that exactly match a set of attributes.  The match is successful if all the attributes of the request are found in a profile, even if the profile has more attributes that are not present on the request.  [Customer Profile]: https://help.talon.one/hc/en-us/articles/360005130739-Data-Model#CustomerProfile 
      * @param body  (required)
      * @param _callback The callback to be executed when the API call finishes
@@ -3866,7 +3866,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Applications Events
+     * List Applications Events (with total count)
      * Lists all events recorded for an application. 
      * @param applicationId  (required)
      * @param pageSize The number of items to include in this response. When omitted, the maximum value of 1000 will be used. (optional)
@@ -3897,7 +3897,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Applications Events
+     * List Applications Events (with total count)
      * Lists all events recorded for an application. 
      * @param applicationId  (required)
      * @param pageSize The number of items to include in this response. When omitted, the maximum value of 1000 will be used. (optional)
@@ -3929,7 +3929,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Applications Events (asynchronously)
+     * List Applications Events (with total count) (asynchronously)
      * Lists all events recorded for an application. 
      * @param applicationId  (required)
      * @param pageSize The number of items to include in this response. When omitted, the maximum value of 1000 will be used. (optional)
@@ -5762,7 +5762,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Coupons
+     * List Coupons (with total count)
      * 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -5796,7 +5796,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Coupons
+     * List Coupons (with total count)
      * 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -5831,7 +5831,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Coupons (asynchronously)
+     * List Coupons (with total count) (asynchronously)
      * 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -6221,7 +6221,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
      * Gets a list of all the coupons with attributes matching the query criteria Application wide 
      * @param applicationId  (required)
      * @param body  (required)
@@ -6252,7 +6252,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
      * Gets a list of all the coupons with attributes matching the query criteria Application wide 
      * @param applicationId  (required)
      * @param body  (required)
@@ -6284,7 +6284,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application (asynchronously)
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count) (asynchronously)
      * Gets a list of all the coupons with attributes matching the query criteria Application wide 
      * @param applicationId  (required)
      * @param body  (required)
@@ -6809,7 +6809,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get Activity Reports for Application Customers
+     * Get Activity Reports for Application Customers (with total count)
      * Fetch summary reports for all application customers based on a time range
      * @param rangeStart Only return results from after this timestamp, must be an RFC3339 timestamp string (required)
      * @param rangeEnd Only return results from before this timestamp, must be an RFC3339 timestamp string (required)
@@ -6835,7 +6835,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get Activity Reports for Application Customers
+     * Get Activity Reports for Application Customers (with total count)
      * Fetch summary reports for all application customers based on a time range
      * @param rangeStart Only return results from after this timestamp, must be an RFC3339 timestamp string (required)
      * @param rangeEnd Only return results from before this timestamp, must be an RFC3339 timestamp string (required)
@@ -6862,7 +6862,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get Activity Reports for Application Customers (asynchronously)
+     * Get Activity Reports for Application Customers (with total count) (asynchronously)
      * Fetch summary reports for all application customers based on a time range
      * @param rangeStart Only return results from after this timestamp, must be an RFC3339 timestamp string (required)
      * @param rangeEnd Only return results from before this timestamp, must be an RFC3339 timestamp string (required)
@@ -8441,7 +8441,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Referrals
+     * List Referrals (with total count)
      * 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -8468,7 +8468,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Referrals
+     * List Referrals (with total count)
      * 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -8496,7 +8496,7 @@ public class ManagementApi {
     }
 
     /**
-     * List Referrals (asynchronously)
+     * List Referrals (with total count) (asynchronously)
      * 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -10305,7 +10305,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes
+     * Get a list of the coupons that match the given attributes (with total count)
      * Gets a list of all the coupons with attributes matching the query criteria 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -10336,7 +10336,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes
+     * Get a list of the coupons that match the given attributes (with total count)
      * Gets a list of all the coupons with attributes matching the query criteria 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -10368,7 +10368,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes (asynchronously)
+     * Get a list of the coupons that match the given attributes (with total count) (asynchronously)
      * Gets a list of all the coupons with attributes matching the query criteria 
      * @param applicationId  (required)
      * @param campaignId  (required)
@@ -10529,7 +10529,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
      * Gets a list of all the coupons with attributes matching the query criteria in all active campaigns of an application 
      * @param applicationId  (required)
      * @param body  (required)
@@ -10560,7 +10560,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
      * Gets a list of all the coupons with attributes matching the query criteria in all active campaigns of an application 
      * @param applicationId  (required)
      * @param body  (required)
@@ -10592,7 +10592,7 @@ public class ManagementApi {
     }
 
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application (asynchronously)
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count) (asynchronously)
      * Gets a list of all the coupons with attributes matching the query criteria in all active campaigns of an application 
      * @param applicationId  (required)
      * @param body  (required)

--- a/src/main/java/one/talon/model/LoyaltyLedgerEntry.java
+++ b/src/main/java/one/talon/model/LoyaltyLedgerEntry.java
@@ -52,56 +52,9 @@ public class LoyaltyLedgerEntry {
   @SerializedName(SERIALIZED_NAME_EVENT_I_D)
   private Integer eventID;
 
-  /**
-   * Gets or Sets type
-   */
-  @JsonAdapter(TypeEnum.Adapter.class)
-  public enum TypeEnum {
-    ADDITION("addition"),
-    
-    SUBTRACTION("subtraction");
-
-    private String value;
-
-    TypeEnum(String value) {
-      this.value = value;
-    }
-
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    public static TypeEnum fromValue(String value) {
-      for (TypeEnum b : TypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-
-    public static class Adapter extends TypeAdapter<TypeEnum> {
-      @Override
-      public void write(final JsonWriter jsonWriter, final TypeEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
-      }
-
-      @Override
-      public TypeEnum read(final JsonReader jsonReader) throws IOException {
-        String value =  jsonReader.nextString();
-        return TypeEnum.fromValue(value);
-      }
-    }
-  }
-
   public static final String SERIALIZED_NAME_TYPE = "type";
   @SerializedName(SERIALIZED_NAME_TYPE)
-  private TypeEnum type;
+  private String type;
 
   public static final String SERIALIZED_NAME_AMOUNT = "amount";
   @SerializedName(SERIALIZED_NAME_AMOUNT)
@@ -236,24 +189,24 @@ public class LoyaltyLedgerEntry {
   }
 
 
-  public LoyaltyLedgerEntry type(TypeEnum type) {
+  public LoyaltyLedgerEntry type(String type) {
     
     this.type = type;
     return this;
   }
 
    /**
-   * Get type
+   * The type of the ledger transaction. Possible values are addition, subtraction, expire or expiring (for expiring points ledgers) 
    * @return type
   **/
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(required = true, value = "The type of the ledger transaction. Possible values are addition, subtraction, expire or expiring (for expiring points ledgers) ")
 
-  public TypeEnum getType() {
+  public String getType() {
     return type;
   }
 
 
-  public void setType(TypeEnum type) {
+  public void setType(String type) {
     this.type = type;
   }
 

--- a/src/test/java/one/talon/api/ManagementApiTest.java
+++ b/src/test/java/one/talon/api/ManagementApiTest.java
@@ -354,7 +354,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * Get access logs for application
+     * Get access logs for application (with total count)
      *
      * 
      *
@@ -571,7 +571,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * Get a list of the customer profiles that match the given attributes
+     * Get a list of the customer profiles that match the given attributes (with total count)
      *
      * Gets a list of all the customer profiles for the account that exactly match a set of attributes.  The match is successful if all the attributes of the request are found in a profile, even if the profile has more attributes that are not present on the request.  [Customer Profile]: https://help.talon.one/hc/en-us/articles/360005130739-Data-Model#CustomerProfile 
      *
@@ -606,7 +606,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * List Applications Events
+     * List Applications Events (with total count)
      *
      * Lists all events recorded for an application. 
      *
@@ -865,7 +865,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * List Coupons
+     * List Coupons (with total count)
      *
      * 
      *
@@ -928,7 +928,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
      *
      * Gets a list of all the coupons with attributes matching the query criteria Application wide 
      *
@@ -1008,7 +1008,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * Get Activity Reports for Application Customers
+     * Get Activity Reports for Application Customers (with total count)
      *
      * Fetch summary reports for all application customers based on a time range
      *
@@ -1236,7 +1236,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * List Referrals
+     * List Referrals (with total count)
      *
      * 
      *
@@ -1494,7 +1494,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * Get a list of the coupons that match the given attributes
+     * Get a list of the coupons that match the given attributes (with total count)
      *
      * Gets a list of all the coupons with attributes matching the query criteria 
      *
@@ -1524,7 +1524,7 @@ public class ManagementApiTest {
     }
     
     /**
-     * Get a list of the coupons that match the given attributes in all active campaigns of an application
+     * Get a list of the coupons that match the given attributes in all active campaigns of an application (with total count)
      *
      * Gets a list of all the coupons with attributes matching the query criteria in all active campaigns of an application 
      *


### PR DESCRIPTION
 - Fix `LoyaltyLedgerEntry`'s `type` property values, failing to parse when retrieving values from the API
 - Flag API operations that return _total count_ in their name for better visibility