### PR TITLE
v4.3.1: Introduce `triggeredByCoupon` property for Effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>one.talon</groupId>
   <artifactId>talon-one-client</artifactId>
-  <version>4.3.0</version>
+  <version>4.3.1</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -59,7 +59,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "one.talon:talon-one-client:4.3.0"
+compile "one.talon:talon-one-client:4.3.1"
 ```
 
 ### Others
@@ -72,7 +72,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/talon-one-client-4.3.0.jar`
+* `target/talon-one-client-4.3.1.jar`
 * `target/lib/*.jar`
 
 ## Getting Started

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5212,6 +5212,7 @@ components:
         couponPattern:
           description: |
             The pattern that will be used to generate coupon codes. The character `#` acts as a placeholder and will be replaced by a random character from the `validCharacters` set.
+          maxLength: 100
           minLength: 3
           type: string
       required:
@@ -6750,6 +6751,7 @@ components:
         couponPattern:
           description: |
             The pattern that will be used to generate coupon codes. The character `#` acts as a placeholder and will be replaced by a random character from the `validCharacters` set.
+          maxLength: 100
           minLength: 3
           type: string
       required:
@@ -6817,6 +6819,7 @@ components:
         couponPattern:
           description: |
             The pattern that will be used to generate coupon codes. The character `#` acts as a placeholder and will be replaced by a random character from the `validCharacters` set.
+          maxLength: 100
           minLength: 3
           type: string
       required:
@@ -8551,10 +8554,12 @@ components:
           type: string
         coupon:
           description: Any coupon code entered.
+          maxLength: 100
           title: Coupon entered in session
           type: string
         referral:
           description: Any referral code entered.
+          maxLength: 100
           title: Referral code entered in session
           type: string
         state:
@@ -8646,11 +8651,13 @@ components:
         couponCodes:
           description: Any coupon codes entered.
           items:
+            maxLength: 100
             type: string
           title: Coupons entered in session
           type: array
         referralCode:
           description: Any referral code entered.
+          maxLength: 100
           title: Referral code entered in session
           type: string
         state:
@@ -8873,10 +8880,12 @@ components:
           type: string
         coupon:
           description: Any coupon code entered.
+          maxLength: 100
           title: Coupon entered in session
           type: string
         referral:
           description: Any referral code entered.
+          maxLength: 100
           title: Referral code entered in session
           type: string
         state:
@@ -9012,11 +9021,13 @@ components:
         couponCodes:
           description: Any coupon codes entered.
           items:
+            maxLength: 100
             type: string
           title: Coupons entered in session
           type: array
         referralCode:
           description: Any referral code entered.
+          maxLength: 100
           title: Referral code entered in session
           type: string
         state:
@@ -9487,12 +9498,14 @@ components:
           ruleIndex: 8
           campaignId: 4
           ruleName: ruleName
+          triggeredByCoupon: 4
           effectType: effectType
           props: '{}'
         - rulesetId: 6
           ruleIndex: 8
           campaignId: 4
           ruleName: ruleName
+          triggeredByCoupon: 4
           effectType: effectType
           props: '{}'
         referral:
@@ -12172,6 +12185,7 @@ components:
         ruleIndex: 8
         campaignId: 4
         ruleName: ruleName
+        triggeredByCoupon: 4
         effectType: effectType
         props: '{}'
       properties:
@@ -12192,6 +12206,10 @@ components:
         effectType:
           description: The type of effect that was triggered
           type: string
+        triggeredByCoupon:
+          description: The ID of the coupon that was being evaluated when this effect
+            was triggered
+          type: integer
         props:
           type: object
       required:
@@ -12223,6 +12241,10 @@ components:
         effectType:
           description: The type of effect that was triggered
           type: string
+        triggeredByCoupon:
+          description: The ID of the coupon that was being evaluated when this effect
+            was triggered
+          type: integer
       required:
       - campaignId
       - effectType
@@ -12804,12 +12826,14 @@ components:
             ruleIndex: 8
             campaignId: 4
             ruleName: ruleName
+            triggeredByCoupon: 4
             effectType: effectType
             props: '{}'
           - rulesetId: 6
             ruleIndex: 8
             campaignId: 4
             ruleName: ruleName
+            triggeredByCoupon: 4
             effectType: effectType
             props: '{}'
           referral:
@@ -13163,12 +13187,14 @@ components:
             ruleIndex: 8
             campaignId: 4
             ruleName: ruleName
+            triggeredByCoupon: 4
             effectType: effectType
             props: '{}'
           - rulesetId: 6
             ruleIndex: 8
             campaignId: 4
             ruleName: ruleName
+            triggeredByCoupon: 4
             effectType: effectType
             props: '{}'
           referral:

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'one.talon'
-version = '4.3.0'
+version = '4.3.1'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "one.talon",
     name := "talon-one-client",
-    version := "4.3.0",
+    version := "4.3.1",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/docs/Effect.md
+++ b/docs/Effect.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **ruleIndex** | **Integer** | The position of the rule that triggered this effect within the ruleset | 
 **ruleName** | **String** | The name of the rule that triggered this effect | 
 **effectType** | **String** | The type of effect that was triggered | 
+**triggeredByCoupon** | **Integer** | The ID of the coupon that was being evaluated when this effect was triggered |  [optional]
 **props** | [**Object**](.md) |  | 
 
 

--- a/docs/EffectEntity.md
+++ b/docs/EffectEntity.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **ruleIndex** | **Integer** | The position of the rule that triggered this effect within the ruleset | 
 **ruleName** | **String** | The name of the rule that triggered this effect | 
 **effectType** | **String** | The type of effect that was triggered | 
+**triggeredByCoupon** | **Integer** | The ID of the coupon that was being evaluated when this effect was triggered |  [optional]
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>talon-one-client</artifactId>
     <packaging>jar</packaging>
     <name>talon-one-client</name>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
     <url>https://github.com/talon-one/maven-artefacts</url>
     <description>Talon.One unified JAVA SDK. It allows for programmatic access to the integration and management API with their respective authentication strategies</description>
     <scm>

--- a/src/main/java/one/talon/ApiClient.java
+++ b/src/main/java/one/talon/ApiClient.java
@@ -128,7 +128,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("OpenAPI-Generator/4.3.0/java");
+        setUserAgent("OpenAPI-Generator/4.3.1/java");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/one/talon/model/Effect.java
+++ b/src/main/java/one/talon/model/Effect.java
@@ -50,6 +50,10 @@ public class Effect {
   @SerializedName(SERIALIZED_NAME_EFFECT_TYPE)
   private String effectType;
 
+  public static final String SERIALIZED_NAME_TRIGGERED_BY_COUPON = "triggeredByCoupon";
+  @SerializedName(SERIALIZED_NAME_TRIGGERED_BY_COUPON)
+  private Integer triggeredByCoupon;
+
   public static final String SERIALIZED_NAME_PROPS = "props";
   @SerializedName(SERIALIZED_NAME_PROPS)
   private Object props;
@@ -165,6 +169,29 @@ public class Effect {
   }
 
 
+  public Effect triggeredByCoupon(Integer triggeredByCoupon) {
+    
+    this.triggeredByCoupon = triggeredByCoupon;
+    return this;
+  }
+
+   /**
+   * The ID of the coupon that was being evaluated when this effect was triggered
+   * @return triggeredByCoupon
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The ID of the coupon that was being evaluated when this effect was triggered")
+
+  public Integer getTriggeredByCoupon() {
+    return triggeredByCoupon;
+  }
+
+
+  public void setTriggeredByCoupon(Integer triggeredByCoupon) {
+    this.triggeredByCoupon = triggeredByCoupon;
+  }
+
+
   public Effect props(Object props) {
     
     this.props = props;
@@ -201,12 +228,13 @@ public class Effect {
         Objects.equals(this.ruleIndex, effect.ruleIndex) &&
         Objects.equals(this.ruleName, effect.ruleName) &&
         Objects.equals(this.effectType, effect.effectType) &&
+        Objects.equals(this.triggeredByCoupon, effect.triggeredByCoupon) &&
         Objects.equals(this.props, effect.props);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(campaignId, rulesetId, ruleIndex, ruleName, effectType, props);
+    return Objects.hash(campaignId, rulesetId, ruleIndex, ruleName, effectType, triggeredByCoupon, props);
   }
 
 
@@ -219,6 +247,7 @@ public class Effect {
     sb.append("    ruleIndex: ").append(toIndentedString(ruleIndex)).append("\n");
     sb.append("    ruleName: ").append(toIndentedString(ruleName)).append("\n");
     sb.append("    effectType: ").append(toIndentedString(effectType)).append("\n");
+    sb.append("    triggeredByCoupon: ").append(toIndentedString(triggeredByCoupon)).append("\n");
     sb.append("    props: ").append(toIndentedString(props)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/src/main/java/one/talon/model/EffectEntity.java
+++ b/src/main/java/one/talon/model/EffectEntity.java
@@ -50,6 +50,10 @@ public class EffectEntity {
   @SerializedName(SERIALIZED_NAME_EFFECT_TYPE)
   private String effectType;
 
+  public static final String SERIALIZED_NAME_TRIGGERED_BY_COUPON = "triggeredByCoupon";
+  @SerializedName(SERIALIZED_NAME_TRIGGERED_BY_COUPON)
+  private Integer triggeredByCoupon;
+
 
   public EffectEntity campaignId(Integer campaignId) {
     
@@ -161,6 +165,29 @@ public class EffectEntity {
   }
 
 
+  public EffectEntity triggeredByCoupon(Integer triggeredByCoupon) {
+    
+    this.triggeredByCoupon = triggeredByCoupon;
+    return this;
+  }
+
+   /**
+   * The ID of the coupon that was being evaluated when this effect was triggered
+   * @return triggeredByCoupon
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The ID of the coupon that was being evaluated when this effect was triggered")
+
+  public Integer getTriggeredByCoupon() {
+    return triggeredByCoupon;
+  }
+
+
+  public void setTriggeredByCoupon(Integer triggeredByCoupon) {
+    this.triggeredByCoupon = triggeredByCoupon;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -174,12 +201,13 @@ public class EffectEntity {
         Objects.equals(this.rulesetId, effectEntity.rulesetId) &&
         Objects.equals(this.ruleIndex, effectEntity.ruleIndex) &&
         Objects.equals(this.ruleName, effectEntity.ruleName) &&
-        Objects.equals(this.effectType, effectEntity.effectType);
+        Objects.equals(this.effectType, effectEntity.effectType) &&
+        Objects.equals(this.triggeredByCoupon, effectEntity.triggeredByCoupon);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(campaignId, rulesetId, ruleIndex, ruleName, effectType);
+    return Objects.hash(campaignId, rulesetId, ruleIndex, ruleName, effectType, triggeredByCoupon);
   }
 
 
@@ -192,6 +220,7 @@ public class EffectEntity {
     sb.append("    ruleIndex: ").append(toIndentedString(ruleIndex)).append("\n");
     sb.append("    ruleName: ").append(toIndentedString(ruleName)).append("\n");
     sb.append("    effectType: ").append(toIndentedString(effectType)).append("\n");
+    sb.append("    triggeredByCoupon: ").append(toIndentedString(triggeredByCoupon)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/test/java/one/talon/model/EffectEntityTest.java
+++ b/src/test/java/one/talon/model/EffectEntityTest.java
@@ -80,4 +80,12 @@ public class EffectEntityTest {
         // TODO: test effectType
     }
 
+    /**
+     * Test the property 'triggeredByCoupon'
+     */
+    @Test
+    public void triggeredByCouponTest() {
+        // TODO: test triggeredByCoupon
+    }
+
 }

--- a/src/test/java/one/talon/model/EffectTest.java
+++ b/src/test/java/one/talon/model/EffectTest.java
@@ -81,6 +81,14 @@ public class EffectTest {
     }
 
     /**
+     * Test the property 'triggeredByCoupon'
+     */
+    @Test
+    public void triggeredByCouponTest() {
+        // TODO: test triggeredByCoupon
+    }
+
+    /**
      * Test the property 'props'
      */
     @Test


### PR DESCRIPTION
## Summary

### Integration API

Introducing property `triggeredByCoupon` on [`Effect`](https://github.com/talon-one/TalonOneJavaSdk/blob/master/src/main/java/one/talon/model/Effect.java) entities returned from our integration API, which holds the `id` of the related coupon.

This should increase observability and allow to make deductions with regard to whether an effect was triggered directly by a coupon.

In order to match the coupon from the property, pass `coupons` as part of the `responseContent` array passed to the  [`/v2/customer_session` endpoint](https://developers.talon.one/Integration-API/API-Reference#updateCustomerSessionV2). Then you would be able to lookup the `id` of the returned coupons and match the corresponding one to the property from the new field `triggeredByCoupon`.