### PR TITLE
v5.0.2: fix notification campaign class enum missing values

### DIFF
--- a/docs/Campaign.md
+++ b/docs/Campaign.md
@@ -54,7 +54,7 @@ Name | Value
 ENABLED | &quot;enabled&quot;
 DISABLED | &quot;disabled&quot;
 ARCHIVED | &quot;archived&quot;
-EXPIREfD | &quot;expired&quot;
+EXPIRED | &quot;expired&quot;
 SCHEDULED | &quot;scheduled&quot;
 RUNNING | &quot;running&quot;
 DRAFT | &quot;draft&quot;

--- a/docs/Campaign.md
+++ b/docs/Campaign.md
@@ -54,7 +54,10 @@ Name | Value
 ENABLED | &quot;enabled&quot;
 DISABLED | &quot;disabled&quot;
 ARCHIVED | &quot;archived&quot;
-
+EXPIREfD | &quot;expired&quot;
+SCHEDULED | &quot;scheduled&quot;
+RUNNING | &quot;running&quot;
+DRAFT | &quot;draft&quot;
 
 
 ## Enum: List&lt;FeaturesEnum&gt;

--- a/src/main/java/one/talon/model/Campaign.java
+++ b/src/main/java/one/talon/model/Campaign.java
@@ -83,7 +83,7 @@ public class Campaign {
 
     ARCHIVED("archived"),
 
-    EXPIREfD("expired"),
+    EXPIRED("expired"),
 
     SCHEDULED("scheduled"),
 

--- a/src/main/java/one/talon/model/Campaign.java
+++ b/src/main/java/one/talon/model/Campaign.java
@@ -78,10 +78,18 @@ public class Campaign {
   @JsonAdapter(StateEnum.Adapter.class)
   public enum StateEnum {
     ENABLED("enabled"),
-    
+
     DISABLED("disabled"),
-    
-    ARCHIVED("archived");
+
+    ARCHIVED("archived"),
+
+    EXPIREfD("expired"),
+
+    SCHEDULED("scheduled"),
+
+    RUNNING("running"),
+
+    DRAFT("draft");
 
     private String value;
 


### PR DESCRIPTION
## Problem

Notification's campaign entity is built on top of Campaign's original `StateEnum`, but extending it with a few more calculated-derived states for communicating those to the consumers.

These are not part of the original enum and therefore the constructor of the Campaign Class fails when initiating such instances

## Solution

Extend the `StateEnum` to support the full range of values:
 - `ENABLED` : enabled
 - `DISABLED` : disabled
 - `ARCHIVED` : archived
 - `EXPIRED` : expired
 - `SCHEDULED` : scheduled
 - `RUNNING` : running
 - `DRAFT` : draft