### PR TITLE
Add missing RejectionReason enum values

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24049,6 +24049,7 @@ components:
           - CouponPartOfNotTriggeredCampaign
           - CouponReservationRequired
           - ProfileRequired
+          - CouponLimitReached
           example: CouponNotFound
           type: string
       required:
@@ -24083,6 +24084,7 @@ components:
           - ReferralRejectedByCondition
           - EffectCouldNotBeApplied
           - ReferralPartOfNotTriggeredCampaign
+          - ReferralCustomerAlreadyReferred
           example: ReferralNotFound
           type: string
       required:


### PR DESCRIPTION
Addresses https://github.com/talon-one/TalonOneJavaSdk/issues/39 and https://github.com/talon-one/TalonOneJavaSdk/issues/35. I couldn't find contribution guidelines, nor figure out how to get the openApi generator to run correctly. However, I figured this was at least a start.